### PR TITLE
Fix issue with InstantiateNewClassesSniff

### DIFF
--- a/Sniffs/Classes/InstantiateNewClassesSniff.php
+++ b/Sniffs/Classes/InstantiateNewClassesSniff.php
@@ -58,6 +58,7 @@ class Joomla_Sniffs_Classes_InstantiateNewClassesSniff implements PHP_CodeSniffe
                 switch ($tokens[$cnt]['code'])
                 {
                     case T_SEMICOLON:
+                    case T_COMMA :
                         $valid = true;
                         $running = false;
                         break;


### PR DESCRIPTION
The following line would trigger issues with the InstantiateNewClassesSniff:
$model = new JModelDatabase(new JRegistry, JFactory::getDbo());

This incorrectly finds the JFactory::getDbo() parenthesis and assumes they're there for the JRegistry call. This pull request adds the comma to the list of escape tokens to reset the call.
