### PR TITLE
Allow for negative values in case statements.

### DIFF
--- a/Sniffs/WhiteSpace/OperatorSpacingSniff.php
+++ b/Sniffs/WhiteSpace/OperatorSpacingSniff.php
@@ -193,6 +193,7 @@ class Joomla_Sniffs_WhiteSpace_OperatorSpacingSniff implements PHP_CodeSniffer_S
                 T_DOUBLE_ARROW,
                 T_COLON,
                 T_INLINE_THEN, // the ternary "?"
+                T_CASE,
                 );
 
                 if(in_array($tokens[$prev]['code'], $invalidTokens) === true)


### PR DESCRIPTION
This allow for the following syntax:

```
switch ($var)
{
    case -1:

   break;
   default:
}
```
