### PR TITLE
Fixed ruleset.xml to accomodate change in exclusion pattern processing i...

### DIFF
--- a/ruleset.xml
+++ b/ruleset.xml
@@ -6,11 +6,9 @@
  <exclude-pattern>*\.js</exclude-pattern>
 
  <!-- Exclude 3rd party libraries. -->
- <exclude-pattern>*/phputf8/*</exclude-pattern>
- <exclude-pattern>*/simplepie/*</exclude-pattern>
- <exclude-pattern>*/phpmailer/phpmailer.php</exclude-pattern>
- <exclude-pattern>*/phpmailer/smtp.php</exclude-pattern>
- <exclude-pattern>*/phpmailer/pop3.php</exclude-pattern>
+ <exclude-pattern>*phputf8/*</exclude-pattern>
+ <exclude-pattern>*simplepie/*</exclude-pattern>
+ <exclude-pattern>*phpmailer/*</exclude-pattern>
  <exclude-pattern>*/mootree*.css</exclude-pattern>
  <exclude-pattern>*/mooRainbow.css</exclude-pattern>
  <exclude-pattern>*/modal.css</exclude-pattern>


### PR DESCRIPTION
...n phpcs.  See http://pear.php.net/bugs/bug.php?id=19648.

Since the scan path was libraries there was no leading slash on the path and phpcs was not ignoring the paths.
