### PR TITLE
Relax increment/decrement rule.

### DIFF
--- a/ruleset.xml
+++ b/ruleset.xml
@@ -46,7 +46,9 @@
  <rule ref="Generic.PHP.DeprecatedFunctions"/>
  <rule ref="Generic.PHP.ForbiddenFunctions"/>
 
- <rule ref="Squiz.Operators.IncrementDecrementUsage"/>
+ <rule ref="Squiz.Operators.IncrementDecrementUsage">
+  <exclude name="Squiz.Operators.IncrementDecrementUsage.processAssignment"/>
+ </rule>
  <rule ref="Squiz.WhiteSpace.ScopeClosingBrace"/>
 
  <rule ref="Squiz.Scope.StaticThisUsage"/>


### PR DESCRIPTION
The increment/decrement rule needs to be relaxed because it's saying that `$x += 1` should be replaced with `$x++`.  The develop may intend to make the code more readable.

Citing references for this:

http://stackoverflow.com/questions/971312/why-avoid-increment-and-decrement-operators-in-javascript

While there may be valid arguments for using increment and decrement as a practice, forcing code to use them should not be part of the coding standard.
