### PR TITLE
Change code style

### DIFF
--- a/Sniffs/NamingConventions/ValidVariableNameSniff.php
+++ b/Sniffs/NamingConventions/ValidVariableNameSniff.php
@@ -54,7 +54,6 @@ class Joomla_Sniffs_NamingConventions_ValidVariableNameSniff extends PHP_CodeSni
         }
 
         $memberName     = ltrim($tokens[$stackPtr]['content'], '$');
-        $isPublic       = ($memberProps['scope'] === 'private') ? false : true;
         $scope          = $memberProps['scope'];
         $scopeSpecified = $memberProps['scope_specified'];
 
@@ -88,16 +87,8 @@ class Joomla_Sniffs_NamingConventions_ValidVariableNameSniff extends PHP_CodeSni
 			$isDeprecated = false;
 		}
 
-        // If it's a private member, it must have an underscore on the front.
-        if ($isPublic === false && $memberName{0} !== '_') {
-            $error = 'Private member variable "%s" must be prefixed with an underscore';
-            $data  = array($memberName);
-            $phpcsFile->addError($error, $stackPtr, 'PrivateNoUnderscore', $data);
-            return;
-        }
-
-        // If it's not a private member, it must not have an underscore on the front.
-        if ($isDeprecated === false && $isPublic === true && $scopeSpecified === true && $memberName{0} === '_') {
+	    // Member vars must not be prefixed by an underscore.
+        if ($isDeprecated === false && $scopeSpecified === true && $memberName{0} === '_') {
             $error = '%s member variable "%s" must not be prefixed with an underscore';
             $data  = array(
                       ucfirst($scope),


### PR DESCRIPTION
This is a proposal to change the current coding style.

The current coding standard enforces an underscore "prefixing" private class member variables.

I believe that this is a relic from bad old pre-PHP 5 times when protected and private members and methods had been decorated this way to provide some sort of "visual aid" to the developer.

Currently a checkstyle **error** is thrown when a private class member is declared **without** an underscore.
This proposes to change this behavior to emit a **warning** if a private member **has** an underscore.

This will obviously raise the warnings emitted by the style checker on the current code base. 
The next step would be to change those offending names, which should be save to do, and maybe change the warning to error.
