### PR TITLE
Exclude folders not containing production or test PHP code

### DIFF
--- a/ruleset.xml
+++ b/ruleset.xml
@@ -12,6 +12,10 @@
  <exclude-pattern>*/mootree*.css</exclude-pattern>
  <exclude-pattern>*/mooRainbow.css</exclude-pattern>
  <exclude-pattern>*/modal.css</exclude-pattern>
+ 
+ <!-- Exclude folders not containing production or test PHP code. -->
+ <exclude-pattern>*build/*</exclude-pattern>
+ <exclude-pattern>*docs/*</exclude-pattern>
 
  <!-- Include all sniffs in an external standard directory -->
 


### PR DESCRIPTION
This PR modifies the sniffer to ignore folders which we do not enforce our code standards on, which includes the build (contains all of the sniffs) and docs (doesn't contain any PHP files) folders.
