### PR TITLE
Don't mark as error when inline control structures are used inside a tmpl

### DIFF
--- a/Sniffs/ControlStructures/ControlSignatureSniff.php
+++ b/Sniffs/ControlStructures/ControlSignatureSniff.php
@@ -83,20 +83,18 @@ class Joomla_Sniffs_ControlStructures_ControlSignatureSniff extends PHP_CodeSnif
 	protected function processPattern($patternInfo, PHP_CodeSniffer_File $phpcsFile
 	, $stackPtr)
 	{
-		if(0)
+		/*
+		 * This is a special sniff for the Joomla! CMS to exclude
+		 * the tmpl folder which may contain constructs in colon notation
+		 */
+
+		$parts = explode(DIRECTORY_SEPARATOR, $phpcsFile->getFileName());
+
+		if('tmpl' == $parts[count($parts) - 2])
 		{
-			/*
-			 * @todo disabled - This is a special sniff for the Joomla! CMS to exclude
-			* the tmpl folder which may contain constructs in colon notation
-			*/
-
-			$parts = explode(DIRECTORY_SEPARATOR, $phpcsFile->getFileName());
-
-			if('tmpl' == $parts[count($parts) - 2])
-			{
-				return false;
-			}
+			return false;
 		}
+
 
 		return parent::processPattern($patternInfo, $phpcsFile, $stackPtr);
 	}//function


### PR DESCRIPTION
Please see this debate: https://groups.google.com/d/msg/joomla-dev-platform/pp1euSmynbw/Z4je-5dB9B8J
