### PR TITLE
Allowing inline comments in control structures

### DIFF
--- a/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
+++ b/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
@@ -180,7 +180,8 @@ class Joomla_Sniffs_WhiteSpace_ControlStructureSpacingSniff implements PHP_CodeS
 				// T_ELSE
 				if ($tokens[$trailingContent]['code'] != T_ELSEIF
 					&& $tokens[$trailingContent]['code'] != T_ELSE
-					&& $tokens[$trailingContent]['code'] != T_CATCH)
+					&& $tokens[$trailingContent]['code'] != T_CATCH
+					&& $tokens[$trailingContent]['code'] != T_COMMENT)
 				{
 					$error = 'No blank line found after control structure' . $tokens[$trailingContent]['line']
 						. ' - ' . $tokens[$trailingContent]['code'];


### PR DESCRIPTION
See Issue #22 

The exact error is
`Error | No blank line found after control structure - 370`.
