### PR TITLE
Adding additional rules

### DIFF
--- a/ruleset.xml
+++ b/ruleset.xml
@@ -5,6 +5,8 @@
 	<!-- Include all sniffs in an external standard directory -->
 
 	<!-- Include some additional sniffs from the Generic standard -->
+	<rule ref="Generic.CodeAnalysis.UselessOverridingMethod" />
+	<rule ref="Generic.Files.EndFileNewline" />
 	<!-- Use Unix newlines -->
 	<rule ref="Generic.Files.LineEndings">
 		<properties>
@@ -44,6 +46,7 @@
 	<rule ref="Squiz.CSS.MissingColon" />
 	<rule ref="Squiz.CSS.SemicolonSpacing" />
 	<rule ref="Squiz.Classes.SelfMemberReference" />
+	<rule ref="Squiz.Commenting.DocCommentAlignment" />
 	<rule ref="Squiz.Operators.IncrementDecrementUsage">
 		<exclude name="Squiz.Operators.IncrementDecrementUsage.processAssignment" />
 	</rule>


### PR DESCRIPTION
This PR will add three new rules to the ruleset here:
- Generic.CodeAnalysis.UselessOverridingMethod - Checks for methods whose only function is to call its parent
- Generic.Files.EndFileNewline - Makes sure all files end in a blank line
- Squiz.Commenting.DocCommentAlignment - Ensures the asterisks in doc blocks are aligned correctly

Also reformats the XML file to group the standards together and makes it easier to edit in an IDE (who indents XML files with single spaces at each level!?  LOL).
