### PR TITLE
Adapted Eclipse formater to work on Kepler

### DIFF
--- a/IDE/eclipse_pdt3_formatter.xml
+++ b/IDE/eclipse_pdt3_formatter.xml
@@ -1,233 +1,206 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<profiles version="1">
-<profile kind="PDTToolsCodeFormatterProfile" name="Joomla" version="1">
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_new_line_in_empty_block" value="insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.indent_body_declarations_compare_to_type_header" value="true"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_before_comma_in_superinterfaces" value="do not insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_after_comma_in_method_declaration_parameters" value="insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_after_comma_in_constructor_declaration_throws" value="insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.indent_switchstatements_compare_to_cases" value="true"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.join_lines_in_comments" value="true"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_after_comma_in_superinterfaces" value="insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_after_comma_in_type_arguments" value="insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_before_comma_in_constructor_declaration_parameters" value="do not insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.blank_lines_between_type_declarations" value="1"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_before_opening_bracket_in_array_reference" value="do not insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_before_opening_bracket_in_array_allocation_expression" value="do not insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.continuation_indentation_for_array_initializer" value="1"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.alignment_for_throws_clause_in_constructor_declaration" value="16"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.alignment_for_throws_clause_in_method_declaration" value="16"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_before_opening_paren_in_synchronized" value="insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.wrap_before_binary_operator" value="true"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_after_comma_in_constructor_declaration_parameters" value="insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_before_comma_in_explicitconstructorcall_arguments" value="do not insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.lineSplit" value="150"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_before_closing_angle_bracket_in_type_arguments" value="do not insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.align_type_members_on_columns" value="false"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_before_opening_brace_in_anonymous_type_declaration" value="insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_before_closing_bracket_in_array_allocation_expression" value="do not insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_after_colon_in_assert" value="insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.brace_position_for_anonymous_type_declaration" value="end_of_line"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_before_opening_paren_in_constructor_declaration" value="do not insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_after_opening_paren_in_synchronized" value="do not insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.put_empty_statement_on_new_line" value="true"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.wrap_array_in_arguments" value="true"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.alignment_for_arguments_in_allocation_expression" value="16"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_before_closing_paren_in_constructor_declaration" value="do not insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.alignment_for_superclass_in_type_declaration" value="16"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_new_line_after_label" value="do not insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_before_closing_brace_in_array_initializer" value="do not insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.alignment_for_selector_in_method_invocation" value="16"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_after_prefix_operator" value="do not insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_new_line_in_empty_anonymous_type_declaration" value="insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_after_opening_paren_in_catch" value="do not insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_after_opening_paren_in_parenthesized_expression" value="do not insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_new_line_at_end_of_file_if_missing" value="do not insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.alignment_for_method_declaration" value="0"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_before_opening_paren_in_for" value="insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_after_assignment_operator" value="insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_before_closing_paren_in_if" value="do not insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_between_brackets_in_array_type_reference" value="do not insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.alignment_for_multiple_fields" value="16"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_before_opening_brace_in_constructor_declaration" value="insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.alignment_for_conditional_expression" value="16"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.indent_empty_lines" value="false"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_before_double_arrow_operator" value="insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_before_comma_in_for_inits" value="do not insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_after_comma_in_explicitconstructorcall_arguments" value="insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_after_semicolon_in_for" value="insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_after_binary_operator" value="insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_before_opening_paren_in_catch" value="insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_before_opening_brace_in_type_declaration" value="insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.indent_statements_compare_to_block" value="true"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_before_closing_bracket_in_array_reference" value="do not insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_before_colon_in_for" value="insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.use_on_off_tags" value="false"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.brace_position_for_type_declaration" value="next_line"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.blank_lines_before_new_chunk" value="1"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.indentation.size" value="4"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_after_comma_in_type_parameters" value="insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.blank_lines_between_import_groups" value="1"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.blank_lines_before_first_class_body_declaration" value="0"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_before_comma_in_type_parameters" value="do not insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.never_indent_line_comments_on_first_column" value="false"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_after_opening_bracket_in_array_allocation_expression" value="do not insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_after_comma_in_method_invocation_arguments" value="insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_before_and_in_type_parameter" value="insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_before_double_colon_operator" value="do not insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_after_comma_in_method_declaration_throws" value="insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.brace_position_for_block" value="next_line"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_before_closing_paren_in_catch" value="do not insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.brace_position_for_array_initializer" value="end_of_line"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_before_colon_in_default" value="do not insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_after_colon_in_for" value="insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.blank_lines_before_imports" value="1"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_before_comma_in_method_declaration_parameters" value="do not insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_after_comma_in_array_initializer" value="insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.keep_else_statement_on_same_line" value="false"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_between_empty_parens_in_method_declaration" value="do not insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_after_comma_in_allocation_expression" value="insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.alignment_for_binary_expression" value="16"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_before_comma_in_method_declaration_throws" value="do not insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_after_opening_paren_in_while" value="do not insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.blank_lines_after_package" value="1"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_before_question_in_wildcard" value="do not insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_new_line_before_while_in_do_statement" value="insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_before_comma_in_for_increments" value="do not insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_before_comma_in_multiple_local_declarations" value="do not insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_before_closing_paren_in_cast" value="do not insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_before_double_arrow_operator_with_filler" value="do not insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_after_comma_in_multiple_field_declarations" value="insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.alignment_for_assignment" value="0"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_before_closing_angle_bracket_in_parameterized_type_reference" value="do not insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_after_colon_in_labeled_statement" value="insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.indent_switchstatements_compare_to_switch" value="true"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_between_empty_parens_in_method_invocation" value="do not insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.alignment_for_arguments_in_explicit_constructor_call" value="16"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.indent_breaks_compare_to_cases" value="true"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_after_opening_paren_in_cast" value="do not insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_after_question_in_wildcard" value="do not insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_after_question_in_conditional" value="insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.tabulation.size" value="4"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_before_ellipsis" value="do not insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_after_opening_angle_bracket_in_type_parameters" value="do not insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_before_semicolon_in_for" value="do not insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_after_comma_in_for_inits" value="insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_before_opening_brace_in_method_declaration" value="insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_after_double_colon_operator" value="do not insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.compact_else_if" value="true"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.keep_then_statement_on_same_line" value="false"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_after_closing_paren_in_cast" value="insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_new_line_before_catch_in_try_statement" value="insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_after_object_operator" value="do not insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_after_opening_paren_in_constructor_declaration" value="do not insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_before_opening_paren_in_parenthesized_expression" value="do not insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_after_ellipsis" value="insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.alignment_for_parameters_in_constructor_declaration" value="16"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_after_opening_paren_in_method_declaration" value="do not insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_before_colon_in_assert" value="insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.format_html_region" value="false"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_after_postfix_operator" value="do not insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_after_comma_in_multiple_local_declarations" value="insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_after_opening_bracket_in_array_reference" value="do not insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.wrap_outer_expressions_when_nested" value="true"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_after_and_in_type_parameter" value="insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_before_opening_brace_in_array_initializer" value="do not insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.use_tabs_only_for_leading_indentations" value="false"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_before_question_in_conditional" value="insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_before_semicolon" value="do not insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_between_empty_braces_in_array_initializer" value="do not insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_after_colon_in_conditional" value="insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_between_empty_parens_in_constructor_declaration" value="do not insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_before_closing_paren_in_for" value="do not insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_before_opening_brace_in_switch" value="insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_before_opening_angle_bracket_in_type_arguments" value="do not insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.alignment_for_parameters_in_method_declaration" value="16"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_before_closing_paren_in_switch" value="do not insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.alignment_for_expressions_in_array_initializer" value="16"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_before_closing_paren_in_parenthesized_expression" value="do not insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_before_binary_operator" value="insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_after_colon_in_case" value="insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.brace_position_for_block_in_case" value="next_line"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_new_line_after_opening_brace_in_array_initializer" value="do not insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_before_comma_in_multiple_field_declarations" value="do not insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_after_unary_operator" value="do not insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_before_closing_angle_bracket_in_type_parameters" value="do not insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_before_colon_in_conditional" value="insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_before_comma_in_type_arguments" value="do not insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_before_parenthesized_expression_in_throw" value="insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.align_php_region_with_open_tag" value="false"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_before_closing_paren_in_method_invocation" value="do not insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.brace_position_for_constructor_declaration" value="end_of_line"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.alignment_for_superinterfaces_in_type_declaration" value="16"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.number_of_empty_lines_to_preserve" value="1"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_before_opening_angle_bracket_in_parameterized_type_reference" value="do not insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_before_comma_in_constructor_declaration_throws" value="do not insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_before_opening_paren_in_method_invocation" value="do not insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_before_parenthesized_expression_in_return" value="insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_before_opening_brace_in_block" value="insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.continuation_indentation" value="1"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.alignment_for_compact_if" value="16"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_after_comma_in_parameterized_type_reference" value="insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_before_opening_angle_bracket_in_type_parameters" value="do not insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.brace_position_for_method_declaration" value="next_line"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_after_opening_paren_in_switch" value="do not insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.blank_lines_before_member_type" value="1"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_before_closing_paren_in_method_declaration" value="do not insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_before_opening_paren_in_method_declaration" value="do not insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_new_line_in_empty_type_declaration" value="insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.number_of_blank_lines_at_beginning_of_method_body" value="0"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_after_closing_brace_in_block" value="insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.alignment_for_arguments_in_method_invocation" value="16"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_after_closing_angle_bracket_in_type_parameters" value="insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.never_indent_block_comments_on_first_column" value="false"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_after_opening_paren_in_method_invocation" value="do not insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_before_opening_bracket_in_array_type_reference" value="do not insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_after_double_arrow_operator" value="insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_after_opening_paren_in_for" value="do not insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_before_opening_paren_in_while" value="insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.format_guardian_clause_on_one_line" value="false"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_before_closing_paren_in_synchronized" value="do not insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_before_parenthesized_expression_in_echo" value="insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.blank_lines_before_field" value="0"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_new_line_before_finally_in_try_statement" value="do not insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_before_closing_paren_in_while" value="do not insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_before_unary_operator" value="do not insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_before_assignment_operator" value="insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_after_opening_paren_in_if" value="do not insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.brace_position_for_switch" value="next_line"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_before_postfix_operator" value="do not insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_before_prefix_operator" value="do not insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_before_comma_in_parameterized_type_reference" value="do not insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_new_line_before_closing_brace_in_array_initializer" value="do not insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.blank_lines_before_method" value="0"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_before_opening_brace_in_namespace_declaration" value="insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_before_colon_in_labeled_statement" value="do not insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_new_line_after_opening_brace_in_array_initializer_in_arguments" value="insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.indent_statements_compare_to_body" value="true"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_before_object_operator" value="do not insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_between_empty_brackets_in_array_allocation_expression" value="do not insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.tabulation.char" value="tab"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_before_colon_in_case" value="do not insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_after_opening_brace_in_array_initializer" value="do not insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.blank_lines_before_package" value="0"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_before_comma_in_array_initializer" value="do not insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_new_line_in_empty_method_body" value="insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_new_line_before_else_in_if_statement" value="insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_before_comma_in_method_invocation_arguments" value="do not insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_before_opening_paren_in_switch" value="insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.indent_body_declarations_compare_to_namespace" value="true"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.join_wrapped_lines" value="true"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_after_closing_angle_bracket_in_type_arguments" value="insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.keep_imple_if_on_one_line" value="false"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_after_opening_angle_bracket_in_parameterized_type_reference" value="do not insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_after_opening_angle_bracket_in_type_arguments" value="do not insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.brace_position_for_namespace_declaration" value="next_line"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_after_comma_in_for_increments" value="insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_before_comma_in_allocation_expression" value="do not insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.blank_lines_after_imports" value="1"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.insert_space_before_opening_paren_in_if" value="insert"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.keep_empty_array_initializer_on_one_line" value="false"/>
-<setting id="jp.sourceforge.pdt_tools.formatter.alignment_for_arguments_in_qualified_allocation_expression" value="16"/>
+<profiles>
+<profile name="Joomla">
+<setting id="indentationChar" value="&#9;"/>
+<setting id="insert_space_after_opening_paren_in_declare" value="false"/>
+<setting id="insert_space_before_closing_paren_in_declare" value="false"/>
+<setting id="insert_space_before_opening_paren_in_declare" value="false"/>
+<setting id="org.eclipse.php.core.formatter.insert_new_line_in_function_invoke" value="3"/>
+<setting id="org.eclipse.php.formatter.core.formatter.alignment_for_arguments_in_allocation_expression_force_split" value="false"/>
+<setting id="org.eclipse.php.formatter.core.formatter.alignment_for_arguments_in_allocation_expression_indent_policy" value="0"/>
+<setting id="org.eclipse.php.formatter.core.formatter.alignment_for_arguments_in_allocation_expression_line_wrap_policy" value="1"/>
+<setting id="org.eclipse.php.formatter.core.formatter.alignment_for_arguments_in_method_invocation_force_split" value="false"/>
+<setting id="org.eclipse.php.formatter.core.formatter.alignment_for_arguments_in_method_invocation_indent_policy" value="0"/>
+<setting id="org.eclipse.php.formatter.core.formatter.alignment_for_arguments_in_method_invocation_line_wrap_policy" value="1"/>
+<setting id="org.eclipse.php.formatter.core.formatter.alignment_for_assignment_force_split" value="false"/>
+<setting id="org.eclipse.php.formatter.core.formatter.alignment_for_assignment_indent_policy" value="0"/>
+<setting id="org.eclipse.php.formatter.core.formatter.alignment_for_assignment_line_wrap_policy" value="0"/>
+<setting id="org.eclipse.php.formatter.core.formatter.alignment_for_binary_expression_force_split" value="false"/>
+<setting id="org.eclipse.php.formatter.core.formatter.alignment_for_binary_expression_indent_policy" value="0"/>
+<setting id="org.eclipse.php.formatter.core.formatter.alignment_for_binary_expression_line_wrap_policy" value="1"/>
+<setting id="org.eclipse.php.formatter.core.formatter.alignment_for_compact_if_force_split" value="false"/>
+<setting id="org.eclipse.php.formatter.core.formatter.alignment_for_compact_if_indent_policy" value="0"/>
+<setting id="org.eclipse.php.formatter.core.formatter.alignment_for_compact_if_line_wrap_policy" value="0"/>
+<setting id="org.eclipse.php.formatter.core.formatter.alignment_for_conditional_expression_force_split" value="false"/>
+<setting id="org.eclipse.php.formatter.core.formatter.alignment_for_conditional_expression_indent_policy" value="0"/>
+<setting id="org.eclipse.php.formatter.core.formatter.alignment_for_conditional_expression_line_wrap_policy" value="0"/>
+<setting id="org.eclipse.php.formatter.core.formatter.alignment_for_expressions_in_array_initializer_force_split" value="true"/>
+<setting id="org.eclipse.php.formatter.core.formatter.alignment_for_expressions_in_array_initializer_indent_policy" value="0"/>
+<setting id="org.eclipse.php.formatter.core.formatter.alignment_for_expressions_in_array_initializer_line_wrap_policy" value="3"/>
+<setting id="org.eclipse.php.formatter.core.formatter.alignment_for_parameters_in_method_declaration_force_split" value="false"/>
+<setting id="org.eclipse.php.formatter.core.formatter.alignment_for_parameters_in_method_declaration_indent_policy" value="0"/>
+<setting id="org.eclipse.php.formatter.core.formatter.alignment_for_parameters_in_method_declaration_line_wrap_policy" value="1"/>
+<setting id="org.eclipse.php.formatter.core.formatter.alignment_for_superclass_in_type_declaration_force_split" value="false"/>
+<setting id="org.eclipse.php.formatter.core.formatter.alignment_for_superclass_in_type_declaration_indent_policy" value="0"/>
+<setting id="org.eclipse.php.formatter.core.formatter.alignment_for_superclass_in_type_declaration_line_wrap_policy" value="0"/>
+<setting id="org.eclipse.php.formatter.core.formatter.alignment_for_superinterfaces_in_type_declaration_force_split" value="false"/>
+<setting id="org.eclipse.php.formatter.core.formatter.alignment_for_superinterfaces_in_type_declaration_indent_policy" value="0"/>
+<setting id="org.eclipse.php.formatter.core.formatter.alignment_for_superinterfaces_in_type_declaration_line_wrap_policy" value="1"/>
+<setting id="org.eclipse.php.formatter.core.formatter.blank_lines_before_field" value="1"/>
+<setting id="org.eclipse.php.formatter.core.formatter.blank_lines_before_member_type" value="1"/>
+<setting id="org.eclipse.php.formatter.core.formatter.blank_lines_before_method" value="1"/>
+<setting id="org.eclipse.php.formatter.core.formatter.blank_lines_between_type_declarations" value="1"/>
+<setting id="org.eclipse.php.formatter.core.formatter.brace_position_for_block" value="1"/>
+<setting id="org.eclipse.php.formatter.core.formatter.brace_position_for_method_declaration" value="1"/>
+<setting id="org.eclipse.php.formatter.core.formatter.brace_position_for_switch" value="1"/>
+<setting id="org.eclipse.php.formatter.core.formatter.brace_position_for_type_declaration" value="1"/>
+<setting id="org.eclipse.php.formatter.core.formatter.comment.clear_blank_lines_in_block_comment" value="false"/>
+<setting id="org.eclipse.php.formatter.core.formatter.comment.clear_blank_lines_in_javadoc_comment" value="false"/>
+<setting id="org.eclipse.php.formatter.core.formatter.comment.format_block_comments" value="true"/>
+<setting id="org.eclipse.php.formatter.core.formatter.comment.format_header" value="false"/>
+<setting id="org.eclipse.php.formatter.core.formatter.comment.format_html" value="true"/>
+<setting id="org.eclipse.php.formatter.core.formatter.comment.format_javadoc_comments" value="true"/>
+<setting id="org.eclipse.php.formatter.core.formatter.comment.format_line_comments" value="true"/>
+<setting id="org.eclipse.php.formatter.core.formatter.comment.format_source_code" value="true"/>
+<setting id="org.eclipse.php.formatter.core.formatter.comment.indent_parameter_description" value="true"/>
+<setting id="org.eclipse.php.formatter.core.formatter.comment.indent_root_tags" value="true"/>
+<setting id="org.eclipse.php.formatter.core.formatter.comment.insert_new_line_before_root_tags" value="true"/>
+<setting id="org.eclipse.php.formatter.core.formatter.comment.insert_new_line_for_parameter" value="true"/>
+<setting id="org.eclipse.php.formatter.core.formatter.comment.line_length" value="80"/>
+<setting id="org.eclipse.php.formatter.core.formatter.comment.new_lines_at_block_boundaries" value="true"/>
+<setting id="org.eclipse.php.formatter.core.formatter.comment.new_lines_at_javadoc_boundaries" value="true"/>
+<setting id="org.eclipse.php.formatter.core.formatter.comment.preserve_white_space_between_code_and_line_comments" value="false"/>
+<setting id="org.eclipse.php.formatter.core.formatter.continuation_indentation" value="2"/>
+<setting id="org.eclipse.php.formatter.core.formatter.continuation_indentation_for_array_initializer" value="2"/>
+<setting id="org.eclipse.php.formatter.core.formatter.disabling_tag" value="@formatter:off"/>
+<setting id="org.eclipse.php.formatter.core.formatter.enabling_tag" value="@formatter:on"/>
+<setting id="org.eclipse.php.formatter.core.formatter.format_guardian_clause_on_one_line" value="false"/>
+<setting id="org.eclipse.php.formatter.core.formatter.format_line_comment_starting_on_first_column" value="true"/>
+<setting id="org.eclipse.php.formatter.core.formatter.indent_body_declarations_compare_to_type_header" value="true"/>
+<setting id="org.eclipse.php.formatter.core.formatter.indent_breaks_compare_to_cases" value="true"/>
+<setting id="org.eclipse.php.formatter.core.formatter.indent_empty_lines" value="false"/>
+<setting id="org.eclipse.php.formatter.core.formatter.indent_statements_compare_to_block" value="true"/>
+<setting id="org.eclipse.php.formatter.core.formatter.indent_statements_compare_to_body" value="true"/>
+<setting id="org.eclipse.php.formatter.core.formatter.indent_switchstatements_compare_to_cases" value="true"/>
+<setting id="org.eclipse.php.formatter.core.formatter.indent_switchstatements_compare_to_switch" value="true"/>
+<setting id="org.eclipse.php.formatter.core.formatter.indentation.size" value="1"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_new_line_after_opening_brace_in_array_initializer" value="false"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_new_line_before_catch_in_try_statement" value="true"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_new_line_before_closing_brace_in_array_initializer" value="true"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_new_line_before_else_in_if_statement" value="true"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_new_line_before_while_in_do_statement" value="true"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_new_line_in_empty_block" value="true"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_new_line_in_empty_method_body" value="true"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_new_line_in_empty_type_declaration" value="true"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_space_after_arrow_in_array_creation" value="true"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_space_after_arrow_in_field_access" value="false"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_space_after_arrow_in_foreach" value="true"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_space_after_arrow_in_method_invocation" value="false"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_space_after_assignment_operator" value="true"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_space_after_binary_operator" value="true"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_space_after_closing_brace_in_block" value="true"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_space_after_closing_paren_in_cast" value="true"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_space_after_colon_in_conditional" value="true"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_space_after_coloncolon_in_field_access" value="false"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_space_after_coloncolon_in_method_invocation" value="false"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_space_after_comma_in_array_creation" value="false"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_space_after_comma_in_echo" value="true"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_space_after_comma_in_for_inits" value="true"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_space_after_comma_in_global" value="true"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_space_after_comma_in_list" value="true"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_space_after_comma_in_method_declaration_parameters" value="true"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_space_after_comma_in_method_invocation_arguments" value="true"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_space_after_comma_in_multiple_constant_declarations" value="true"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_space_after_comma_in_multiple_field_declarations" value="true"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_space_after_comma_in_static" value="true"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_space_after_comma_in_superinterfaces" value="true"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_space_after_opening_bracket_in_array_reference" value="false"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_space_after_opening_paren_in_array_creation" value="false"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_space_after_opening_paren_in_cast" value="false"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_space_after_opening_paren_in_catch" value="false"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_space_after_opening_paren_in_for" value="false"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_space_after_opening_paren_in_foreach" value="false"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_space_after_opening_paren_in_if" value="false"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_space_after_opening_paren_in_list" value="false"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_space_after_opening_paren_in_method_declaration" value="false"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_space_after_opening_paren_in_method_invocation" value="false"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_space_after_opening_paren_in_parenthesized_expression" value="false"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_space_after_opening_paren_in_switch" value="false"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_space_after_opening_paren_in_while" value="false"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_space_after_postfix_operator" value="false"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_space_after_prefix_operator" value="true"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_space_after_question_in_conditional" value="true"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_space_after_semicolon_in_for" value="true"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_space_after_unary_operator" value="true"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_space_before_arrow_in_array_creation" value="true"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_space_before_arrow_in_field_access" value="false"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_space_before_arrow_in_foreach" value="true"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_space_before_arrow_in_method_invocation" value="false"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_space_before_assignment_operator" value="true"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_space_before_binary_operator" value="true"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_space_before_closing_bracket_in_array_reference" value="false"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_space_before_closing_paren_in_array_creation" value="false"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_space_before_closing_paren_in_cast" value="false"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_space_before_closing_paren_in_catch" value="false"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_space_before_closing_paren_in_for" value="false"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_space_before_closing_paren_in_foreach" value="false"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_space_before_closing_paren_in_if" value="false"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_space_before_closing_paren_in_list" value="false"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_space_before_closing_paren_in_method_declaration" value="false"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_space_before_closing_paren_in_method_invocation" value="false"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_space_before_closing_paren_in_parenthesized_expression" value="false"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_space_before_closing_paren_in_switch" value="false"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_space_before_closing_paren_in_while" value="false"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_space_before_colon_in_case" value="false"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_space_before_colon_in_conditional" value="true"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_space_before_colon_in_default" value="false"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_space_before_coloncolon_in_field_access" value="false"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_space_before_coloncolon_in_method_invocation" value="false"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_space_before_comma_in_array_creation" value="false"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_space_before_comma_in_echo" value="false"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_space_before_comma_in_for_inits" value="false"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_space_before_comma_in_global" value="false"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_space_before_comma_in_list" value="false"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_space_before_comma_in_method_declaration_parameters" value="false"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_space_before_comma_in_method_invocation_arguments" value="false"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_space_before_comma_in_multiple_constant_declarations" value="false"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_space_before_comma_in_multiple_field_declarations" value="false"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_space_before_comma_in_static" value="false"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_space_before_comma_in_superinterfaces" value="false"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_space_before_opening_brace_in_block" value="true"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_space_before_opening_brace_in_method_declaration" value="true"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_space_before_opening_brace_in_switch" value="true"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_space_before_opening_brace_in_type_declaration" value="true"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_space_before_opening_bracket_in_array_reference" value="false"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_space_before_opening_paren_in_array_creation" value="false"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_space_before_opening_paren_in_catch" value="true"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_space_before_opening_paren_in_for" value="true"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_space_before_opening_paren_in_foreach" value="true"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_space_before_opening_paren_in_if" value="true"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_space_before_opening_paren_in_list" value="true"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_space_before_opening_paren_in_method_declaration" value="true"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_space_before_opening_paren_in_method_invocation" value="false"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_space_before_opening_paren_in_switch" value="true"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_space_before_opening_paren_in_while" value="true"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_space_before_postfix_operator" value="true"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_space_before_prefix_operator" value="false"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_space_before_question_in_conditional" value="true"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_space_before_semicolon" value="false"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_space_before_semicolon_in_for" value="false"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_space_before_unary_operator" value="false"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_space_between_brackets_in_array_type_reference" value="false"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_space_between_empty_parens_in_method_declaration" value="false"/>
+<setting id="org.eclipse.php.formatter.core.formatter.insert_space_between_empty_parens_in_method_invocation" value="false"/>
+<setting id="org.eclipse.php.formatter.core.formatter.join_lines_in_comments" value="true"/>
+<setting id="org.eclipse.php.formatter.core.formatter.keep_else_statement_on_same_line" value="false"/>
+<setting id="org.eclipse.php.formatter.core.formatter.keep_elseif_statement_on_same_line" value="true"/>
+<setting id="org.eclipse.php.formatter.core.formatter.keep_imple_if_on_one_line" value="false"/>
+<setting id="org.eclipse.php.formatter.core.formatter.keep_then_statement_on_same_line" value="false"/>
+<setting id="org.eclipse.php.formatter.core.formatter.lineSplit" value="150"/>
+<setting id="org.eclipse.php.formatter.core.formatter.never_indent_block_comments_on_first_column" value="false"/>
+<setting id="org.eclipse.php.formatter.core.formatter.never_indent_line_comments_on_first_column" value="false"/>
+<setting id="org.eclipse.php.formatter.core.formatter.number_of_blank_lines_after_namespace" value="0"/>
+<setting id="org.eclipse.php.formatter.core.formatter.number_of_blank_lines_after_use_statements" value="0"/>
+<setting id="org.eclipse.php.formatter.core.formatter.number_of_blank_lines_at_beginning_of_method_body" value="0"/>
+<setting id="org.eclipse.php.formatter.core.formatter.number_of_blank_lines_at_end_of_class_body" value="0"/>
+<setting id="org.eclipse.php.formatter.core.formatter.number_of_blank_lines_at_end_of_method_body" value="0"/>
+<setting id="org.eclipse.php.formatter.core.formatter.number_of_blank_lines_before_namespace" value="0"/>
+<setting id="org.eclipse.php.formatter.core.formatter.number_of_blank_lines_before_use_statements" value="0"/>
+<setting id="org.eclipse.php.formatter.core.formatter.number_of_blank_lines_between_namespaces" value="0"/>
+<setting id="org.eclipse.php.formatter.core.formatter.number_of_blank_lines_between_use_statements" value="0"/>
+<setting id="org.eclipse.php.formatter.core.formatter.number_of_empty_lines_to_preserve" value="1"/>
+<setting id="org.eclipse.php.formatter.core.formatter.put_empty_statement_on_new_line" value="false"/>
+<setting id="org.eclipse.php.formatter.core.formatter.tabulation.size" value="4"/>
+<setting id="org.eclipse.php.formatter.core.formatter.use_on_off_tags" value="false"/>
 </profile>
 </profiles>

--- a/IDE/readme.md
+++ b/IDE/readme.md
@@ -1,7 +1,7 @@
 ## IDE auto formatters
 
-* Eclipse PDT3
-@todo
+* Eclipse PDT
+Go to Preferences->PHP->Code style->Formatter and Import ```eclipse_pdt3_formatter.xml```
 * Zend studio
 @todo
 * PHPStorm


### PR DESCRIPTION
The existing formater was throwing some errors on Eclipse Kepler release. Additionally I had to change some Sniffs to make it work, 
https://github.com/Digital-Peak/coding-standards/commit/c94d9c256b4e9115269a29694dd09bcf279fd4fd
