### PR TITLE
Remove Generic.PHP.ForbiddenFunctions sniff

### DIFF
--- a/ruleset.xml
+++ b/ruleset.xml
@@ -29,7 +29,6 @@
 	<rule ref="Generic.NamingConventions.UpperCaseConstantName" />
 	<rule ref="Generic.PHP.DisallowShortOpenTag" />
 	<rule ref="Generic.PHP.DeprecatedFunctions" />
-	<rule ref="Generic.PHP.ForbiddenFunctions" />
 
 	<!-- Include some additional sniffs from the PEAR standard -->
 	<rule ref="PEAR.Classes.ClassDeclaration" />


### PR DESCRIPTION
This removes the check for the deprecated functions delete() and sizeof().
Those checks are currently choking with namespaced classes with these names.

Like: https://github.com/joomla/jissues/blob/master/src/App/GitHub/Controller/Ajax/Labels/Delete.php#L19

Example Travis log: https://travis-ci.org/joomla/jissues/jobs/14662814
