### PR TITLE
Add alert about PHPCS 2.0 not compatible with our sniffers

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ If you want to contribute and improve this documentation find the source files a
 * PHP 5.3+
 * [PHP Codesniffer](http://pear.php.net/PHP_CodeSniffer) 1.3+
 
+**Important note**: currently the latest PHPCS is the 2.x series. But they are under development so Joomla Sniffers are not yet compatible with this version. PEAR gives you the option to install it by default but  Joomla sniffers will not work, thus remind to always install PHPCS in a version below 2.0.
+
 
 ## Installation
 
@@ -19,7 +21,7 @@ Installation is as easy as checking out the repository to the correct location w
 
 ### Install PHP_CodeSniffer.
 
-	pear install PHP_CodeSniffer
+	pear install PHP_CodeSniffer-1.5.3
 
 ### Install the Joomla standard.
 


### PR DESCRIPTION
Since PHPCS 2.0 is available in PEAR people is installing it but our sniffers are not working with this development package. I'm adding this warning to warn people about installing 1.5 instead.
