### PR TITLE
empty arrays are a valid parameter too

### DIFF
--- a/Sniffs/Classes/InstantiateNewClassesSniff.php
+++ b/Sniffs/Classes/InstantiateNewClassesSniff.php
@@ -72,6 +72,7 @@ class Joomla_Sniffs_Classes_InstantiateNewClassesSniff implements PHP_CodeSniffe
                     case T_LNUMBER :
                     case T_CONSTANT_ENCAPSED_STRING :
                     case T_DOUBLE_QUOTED_STRING :
+                    case T_ARRAY :
                         if($started)
                         {
                             $valid = true;


### PR DESCRIPTION
Without this fix

```
new JInput(array());
```

doesn't work.