### PR TITLE
add Element with only a few attributes

### DIFF
--- a/manual/en-US/coding-standards/chapters/xml.md
+++ b/manual/en-US/coding-standards/chapters/xml.md
@@ -16,17 +16,17 @@ A max line length of 100 characters is recommended for good reading.
 
 #### Examples
 
-Element is **empty**:
+###### Element is **empty**:
 ```xml
 <field
 	name="abc"
 	type="text"
 	label="Empty Field"
 	description="Empty field without options"
-	/>
+/>
 ```
 
-Element is **not empty**:
+###### Element is **not empty**:
 ```xml
 <field
 	name="abc"
@@ -54,4 +54,8 @@ Element is **not empty**:
 		SOMETHING_VERY_LONG
 	</option>
 </field>
+```
+###### Element with only a few attributes
+```xml
+<fieldset name="params" label="Some label for the field set">
 ```


### PR DESCRIPTION
Based on the comment:

>When the element only has few attributes, then the whole element can stay on the same line. A max line length of 100 characters is recommended for good reading.

Here a example for it so it is easy to understand that  `<fieldset>` can be in one line.