### PR TITLE
PHPCS 2.x is stable but Joomla Sniffers is not yet compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ If you want to contribute and improve this documentation find the source files a
 ## Requirements
 
 * PHP 5.3+
-* [PHP Codesniffer](http://pear.php.net/PHP_CodeSniffer) 1.3+
+* [PHP Codesniffer](http://pear.php.net/PHP_CodeSniffer) 1.5+
 
-**Important note**: currently the latest PHPCS is the 2.x series. But they are under development so Joomla Sniffers are not yet compatible with this version. PEAR gives you the option to install it by default but  Joomla sniffers will not work, thus remind to always install PHPCS in a version below 2.0.
+**Important note**: currently the latest PHPCS is the 2.x series. But Joomla Sniffers is not yet compatible with this version. PEAR gives you the option to install it by default but  Joomla sniffers will not work, thus remind to always install PHPCS in a version below 2.0.
 
 
 ## Installation
@@ -21,7 +21,7 @@ Installation is as easy as checking out the repository to the correct location w
 
 ### Install PHP_CodeSniffer.
 
-	pear install PHP_CodeSniffer-1.5.3
+	pear install PHP_CodeSniffer-1.5.6
 
 ### Install the Joomla standard.
 


### PR DESCRIPTION
- Clarify the "Important note" : PHPCS 2.x is stable but Joomla Sniffers is not yet compatible
- Update Requirements to PHPCS 1.5+ from 1.3+
- Update the PHPCS instructions for pear install to 1.5.6 (current 1.5.x release)