### PR TITLE
Better documentation of differences from core standards

### DIFF
--- a/notes.txt
+++ b/notes.txt
@@ -1,33 +1,66 @@
 ==========
-This standard has been derived from the PEAR standard.
+The Joomla coding-standards for PHP_CodeSniffer has been derived from the Generic, PEAR, Squiz, PSR2, and Zend standards.
 Differences are noted below.
 ==========
 
-Files/ClassCommentSniff
-- Added tags to check (copyright, etc not required in classes).
+ruleset.xml
+- Increased notional limit to 150 chars.
+- Include/exclude additional sniffs from various standards (see file for specifics)
 
-Files/FileCommentSniff.php
+Classes/InstantiateNewClassesSniff.php
+Classes/MemberVarScopeSniff.php
+Classes/MethodScopeSniff.php
+Classes/StaticThisUsageSniff.php
+
+Commenting/ClassCommentSniff.php
+- Added tags to check (copyright, etc not required in classes).
+- @package tag optional.
+Commenting/FileCommentSniff.php
 - If not short description is provided then the blank line check is not done.
 - Removed check on subpackage name in processSubpackage
 - Removed space checking after @ tags in processTags
 - Allowed any characters to appear before the copyright year in processCopyrights
-
-Files/FunctionCommentSniff.php
+- @package tag optional.
+Commenting/FunctionCommentSniff.php
 - Remove check for one space before var type.
 - Remove check for 1 space after the longest type.
 - Remove check for 1 space after the variable name.
 - Remove check for variable name alignment.
 - Remove check for variable comment alignment.
+Commenting/SingleCommentSniff.php
 
-Files/IncludeFileSniff.php
-- Removed conditional checking for require/include difference (don't agree with PEAR's stance).
-
-Files/LineLenghtSniff.php
-- Increased notional limit to 130 chars.
-
-WhiteSpace/ScopeIndentSniff.php
-- Removed file (only handles spaces).
-
+ControlStructures/ControlSignatureSniff.php
+ControlStructures/ElseIfDeclarationSniff.php
+- based on PSR2.ControlStructures.ElseIfDeclaration
+- Changed from WARNING to ERROR
 ControlStructures/InlineControlStructureSniff.php
 - Changed from WARNING to ERROR
 - Added exception is the file is a layout (ie, under a /tmpl/ folder).
+ControlStructures/MultiLineConditionSniff.php
+ControlStructures/WhiteSpaceBeforeSniff.php
+
+Functions/FunctionCallSignatureSniff.php
+Functions/FunctionDeclarationSniff.php
+Functions/StatementNotFunctionSniff.php
+
+NamingConventions/ValidFunctionNameSniff.php
+NamingConventions/ValidVariableNameSniff.php
+
+PHP/LowerCaseConstantSniff.php
+- Based on Generic.PHP.LowerCaseConstantSniff
+
+WhiteSpace/CastSpacingSniff.php
+- Squiz.WhiteSpace.CastSpacing
+WhiteSpace/ConcatenationSpacingSniff.php
+WhiteSpace/ControlStructureSpacingSniff.php
+WhiteSpace/DisallowSpaceIndentSniff.php
+- Based on Generic.WhiteSpace.DisallowSpaceIndent
+WhiteSpace/MemberVarSpacingSniff.php
+- Based on Squiz.WhiteSpace.MemberVarSpacing
+WhiteSpace/ObjectOperatorIndentSniff.php
+- Based on PEAR.WhiteSpace.ObjectOperatorIndent
+WhiteSpace/OperatorSpacingSniff.php
+WhiteSpace/SemicolonSpacingSniff.php
+- Based on Squiz.WhiteSpace.SemicolonSpacing
+WhiteSpace/SpaceAfterCastSniff.php
+WhiteSpace/SuperfluousWhitespaceSniff.php


### PR DESCRIPTION
- Try to include some better documentation of differences from core standards to help with current and future PHPCS migration tasks
- Remove IncludeFileSniff this is no longer part of the Joomla standard
- Replace LineLenghtSniff reference with ruleset.xml definition, LineLenghtSniff is no longer part of the Joomla standard
- No need to reference core standard sniffs not included in the joomla/coding-standards, remove reference to ScopeIndentSniff and IncludeFileSniff
- Where it is known, specify the standard the joomla/coding-standards are based on 
- add references to all sniffs that are customized as a Joomla sniff