### PR TITLE
Support installing the PHPCS ruleset via Composer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 .*
+
+# Composer Dependencies
+/vendor
+/composer.lock

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,16 @@
+{
+    "name": "joomla/coding-standard",
+    "description": "Joomla! Coding Standard",
+    "keywords": ["joomla", "coding standard", "phpcs"],
+    "homepage": "https://github.com/joomla/coding-standards",
+    "license": "GPL-2.0+",
+    "require": {
+        "php": ">=5.3.10",
+        "squizlabs/php_codesniffer": "1.*"
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.x-dev"
+        }
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "license": "GPL-2.0+",
     "require": {
         "php": ">=5.3.10",
-        "squizlabs/php_codesniffer": "1.*"
+        "squizlabs/php_codesniffer": "~1.5"
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
For better usability, this PR adds a `composer.json` file to allow the ruleset to be installed by Composer.

Before merging, there needs to be some decisions on how to manage versioning and support infrastructure.  So with that said, my initial thoughts:

- Internal versioning - Since there hasn't been a 1.0 tag at any point in the repo/standard history, the master branch's current state would be tagged as our 1.0 standard.  The PHPCS 2 refactor becomes the 2.0 standard and we do our best within SemVer rules to manage the 1.0 ruleset from this point.
- Major version bumps (AKA B/C breaks) - This can be managed in two ways.  One is that we follow SemVer and be done with it.  The other is that each major version of our standard aligns with a PHPCS major version series.  SemVer probably makes more sense, we just need to make sure it's communicated what version(s) of our standard align to what version(s) of PHPCS.
- Documentation - How do we document certain changes between major versions?  The [gh-pages](http://joomla.github.io/coding-standards/) branch mostly documents the actual standard but not a lot about the software setup/use.  Also, we'll need to consider documentation on deprecations/changes/removals overall.  It's entirely possible someone is extending our custom sniffs somewhere, plus with any luck at some point in the future we could just have the CMS pull this repo for the base standard and extend it with a custom ruleset versus duplicating this stuff in full.