### PR TITLE
Add missing newline to fix formating

### DIFF
--- a/manual/en-US/coding-standards/chapters/docblocks.md
+++ b/manual/en-US/coding-standards/chapters/docblocks.md
@@ -45,6 +45,7 @@ Class definitions, properties and methods must each be provided with a DocBlock 
 #### Class DocBlock Headers
 The class Docblock consists of the following required and optional elements in the fol-lowing order.
 Short description (required, unless the file contains more than two classes or functions), followed by a blank line). Long description (optional, followed by a blank line).
+
 * @category (optional and rarely used)
 * @package (required)
 * @subpackage (optional)


### PR DESCRIPTION
Class DocBlock unordered list is failing to display correctly on the http://joomla.github.io/coding-standards/?coding-standards/chapters/docblocks.md page due to a missing newline before the unordered list.