### PR TITLE
The `@package` tag is no longer required for namespaced code

### DIFF
--- a/manual/en-US/coding-standards/chapters/docblocks.md
+++ b/manual/en-US/coding-standards/chapters/docblocks.md
@@ -47,7 +47,7 @@ The class Docblock consists of the following required and optional elements in t
 Short description (required, unless the file contains more than two classes or functions), followed by a blank line). Long description (optional, followed by a blank line).
 
 * @category (optional and rarely used)
-* @package (required)
+* @package (optional)
 * @subpackage (optional)
 * @author (optional but only permitted in non-Joomla source files, for example, included third-party libraries like Geshi)
 * @copyright (optional unless different from the file Docblock)

--- a/manual/en-US/coding-standards/chapters/docblocks.md
+++ b/manual/en-US/coding-standards/chapters/docblocks.md
@@ -73,8 +73,8 @@ The class property Docblock consists of the following required and optional elem
 Short description (required, followed by a blank line)
 
 * @var (required, followed by the property type)
-* @deprecated (optional)
 * @since (required)
+* @deprecated (optional)
 
 Example of Class property DocBlock:
 

--- a/manual/en-US/coding-standards/chapters/docblocks.md
+++ b/manual/en-US/coding-standards/chapters/docblocks.md
@@ -52,10 +52,10 @@ Short description (required, unless the file contains more than two classes or f
 * @author (optional but only permitted in non-Joomla source files, for example, included third-party libraries like Geshi)
 * @copyright (optional unless different from the file Docblock)
 * @license (optional unless different from the file Docblock)
-* @deprecated (optional)
 * @link (optional)
 * @see (optional)
 * @since (required, being the version of the software the class was introduced)
+* @deprecated (optional)
 
 Example of a Class file DocBlock header:
 ```php


### PR DESCRIPTION
The `@package` and `@subpackage` requirement only existed in Joomla's non-namespaced code. 
These tags aren't required for namespaced code, and are no longer going to be enforced in the standard.