### PR TITLE
override .close span class from bootstrap

### DIFF
--- a/assets/css/themes/github.css
+++ b/assets/css/themes/github.css
@@ -53,6 +53,15 @@ pre .tag, pre .tag-name {
     color: navy;
 }
 
+pre .close {
+    float: none;
+    font-size: 13px;
+    font-weight: normal;
+    line-height: 19px;
+    opacity: 1;
+    text-shadow: none;
+}
+
 pre .keyword, pre .css-property, pre .vendor-prefix, pre .sass, pre .class, pre .id, pre .css-value, pre .entity.function, pre .storage.function {
     font-weight: bold;
 }


### PR DESCRIPTION
The closing tags on all the code samples at https://joomla.github.io/coding-standards/?coding-standards/chapters/html.md are being messed up with a .close span class that is pulling styles from bootstrap.  I am not sure where or how the span classes get added to the markdown source from here https://github.com/joomla/coding-standards/blob/gh-pages/manual/en-US/coding-standards/chapters/html.md

I see two options:
1) find a way to eliminate the inclusion of the .close span class to the closing tags.  I am betting this is done dynamically somewhere and is therefore a non-starter.
2) just override the bootstrap css (this commit).  I hate this as it is adding code to overwrite code that I wish weren't there in the first place.  However, I hate the messed up rendering of a page about coding standards more.