### PR TITLE
Change DocBlock spacing requierment to match the check

### DIFF
--- a/manual/en-US/coding-standards/chapters/docblocks.md
+++ b/manual/en-US/coding-standards/chapters/docblocks.md
@@ -4,7 +4,7 @@ Documentation headers for PHP code in: files, classes, class properties, methods
 
 These "DocBlocks" borrow from the PEAR standard but have some variations specific for Joomla and the Joomla projects.
 
-Whereas normal code indenting uses real tabs, all whitespace in a Docblock uses real spaces. This provides better readability in source code browsers. The minimum whitespace between any text elements, such as tags, variable types, variable names and tag descriptions, is two real spaces. Variable types and tag descriptions should be aligned according to the longest Docblock tag and type-plus-variable respectively.
+Whereas normal code indenting uses real tabs, all whitespace in a Docblock uses real spaces. This provides better readability in source code browsers. The minimum whitespace between any text elements, such as tags, variable types, variable names and tag descriptions, is three real spaces. Variable types and tag descriptions should be aligned according to the longest Docblock tag and type-plus-variable respectively.
 
 Code contributed to the Joomla project that will become the copyright of the project is not allowed to include @author tags. You should update the contribution log in CREDITS.php. Joomla's philosophy is that the code is written "all together" and there is no notion of any one person "owning" any section of code. The @author tags are permitted in third-party libraries that are included in the core libraries.
 


### PR DESCRIPTION
The [existing standard check](https://github.com/joomla/coding-standards/blob/master/Sniffs/Commenting/FunctionCommentSniff.php#L351-L355) doesn't line up with the written standard here. Since the existing standard check has been in use for quite some time, the written standard should be updated to reflect the 3 space minimum