### PR TITLE
Add @throws requirement to methods DocBlock

### DIFF
--- a/manual/en-US/coding-standards/chapters/docblocks.md
+++ b/manual/en-US/coding-standards/chapters/docblocks.md
@@ -98,9 +98,10 @@ Function definitions must include a documentation comment in accordance with the
 * Short description (required, followed by a blank line)
 * Long description (optional, followed by a blank line)
 * @param (required if there are method or function arguments, the last @param tag is followed by a blank line)
-* @throws (required if method or function arguments throw a specific type of exception, the last @throws tag is followed by a blank line)
 * @return (required, followed by a blank line)
-* All other tags in alphabetical order, however @since is always required.
+* @since (required, followed by a blank line if there are additional tags)
+* @throws (required if method or function arguments throws a specific type of exception)
+* All other tags in alphabetical order.
 
 Example of Method DocBlock:
 ```php
@@ -110,12 +111,12 @@ Example of Method DocBlock:
 	 * @param   string  $method  The HTTP method for which to set the class suffix.
 	 * @param   string  $suffix  The class suffix to use when fetching the controller name for a given request.
 	 *
-	 * @throws  InvalidArgumentException   Thrown if the provided arguments is not of type string.
-	 * @throws  \UnexpectedValueException  May be thrown if the container has not been set.
-	 *
 	 * @return  JApplicationWebRouter  This object for method chaining.
 	 *
 	 * @since   12.2
+	 *
+	 * @throws  InvalidArgumentException   Thrown if the provided arguments is not of type string.
+	 * @throws  \UnexpectedValueException  May be thrown if the container has not been set.
 	 */
 	public function setHttpMethodSuffix($method, $suffix)
 ```

--- a/manual/en-US/coding-standards/chapters/docblocks.md
+++ b/manual/en-US/coding-standards/chapters/docblocks.md
@@ -98,6 +98,7 @@ Function definitions must include a documentation comment in accordance with the
 * Short description (required, followed by a blank line)
 * Long description (optional, followed by a blank line)
 * @param (required if there are method or function arguments, the last @param tag is followed by a blank line)
+* @throws (required if method or function arguments throw a specific type of exception, the last @throws tag is followed by a blank line)
 * @return (required, followed by a blank line)
 * All other tags in alphabetical order, however @since is always required.
 
@@ -106,16 +107,15 @@ Example of Method DocBlock:
 	/**
 	 * Set a controller class suffix for a given HTTP method.
 	 *
-	 * @package Joomla.Framework
-	 * @subpackage Router 
-	 *
-	 *
 	 * @param   string  $method  The HTTP method for which to set the class suffix.
 	 * @param   string  $suffix  The class suffix to use when fetching the controller name for a given request.
 	 *
-	 * @return  Router  Returns itself to support chaining.
+	 * @throws  InvalidArgumentException   Thrown if the provided arguments is not of type string.
+	 * @throws  \UnexpectedValueException  May be thrown if the container has not been set.
 	 *
-	 * @since   1.0
+	 * @return  JApplicationWebRouter  This object for method chaining.
+	 *
+	 * @since   12.2
 	 */
 	public function setHttpMethodSuffix($method, $suffix)
 ```


### PR DESCRIPTION
PSR-5 proposal indicates that the `@throws` tag is "RECOMMENDED" for every occurrence of an exception in "Structural Elements"

Already used in the CMS and the framework, Should be a requirement.

Examples are fictional in relation to the method listed and are intended only as instructional guides on tag usage. 

remove `@package` and `@subpackage` as these are not part of method DocBlocks