### PR TITLE
Remove T_ECHO fixes #130

### DIFF
--- a/Sniffs/Functions/StatementNotFunctionSniff.php
+++ b/Sniffs/Functions/StatementNotFunctionSniff.php
@@ -28,7 +28,6 @@ class Joomla_Sniffs_Functions_StatementNotFunctionSniff implements PHP_CodeSniff
 			T_REQUIRE,
 			T_INCLUDE,
 			T_CLONE,
-			T_ECHO
 		);
 	}
 


### PR DESCRIPTION
`echo` should be allowed to be used with or without parenthesis 

fixes #130 