### PR TITLE
Bump minimum phpCS to 2.8.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ If you want to contribute and improve this documentation find the source files a
 ## Requirements
 
 * PHP 5.3+
-* [PHP Codesniffer](https://github.com/squizlabs/PHP_CodeSniffer) 2.7+
+* [PHP Codesniffer](https://github.com/squizlabs/PHP_CodeSniffer) 2.8+
 
 ## Installation
 
@@ -18,7 +18,7 @@ Installation is as easy as checking out the repository to the correct location w
 
 ### Install PHP_CodeSniffer.
 
-	pear install PHP_CodeSniffer-2.7.*
+	pear install PHP_CodeSniffer-2.8.*
 
 ### Install the Joomla standard.
 

--- a/composer.json
+++ b/composer.json
@@ -13,14 +13,14 @@
     ],
     "require": {
         "php": ">=5.3.10",
-        "squizlabs/php_codesniffer": "^2.7.0"
+        "squizlabs/php_codesniffer": "^2.8.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8.7"
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "2.x-dev"
+            "dev-master": "3.x-dev"
         }
     },
     "scripts": {


### PR DESCRIPTION
phpCS 2.8.x has enough improvements that we should recommend that as a minimum