### PR TITLE
[PHPCS2] fix file vs class reporting of errors

### DIFF
--- a/Joomla/Sniffs/Commenting/FileCommentSniff.php
+++ b/Joomla/Sniffs/Commenting/FileCommentSniff.php
@@ -209,7 +209,7 @@ class Joomla_Sniffs_Commenting_FileCommentSniff implements PHP_CodeSniffer_Sniff
 	{
 		$tokens = $phpcsFile->getTokens();
 
-		if (get_class($this) === 'PEAR_Sniffs_Commenting_FileCommentSniff')
+		if (get_class($this) === 'Joomla_Sniffs_Commenting_FileCommentSniff')
 		{
 			$docBlock = 'file';
 		}


### PR DESCRIPTION
this needs to be the same class as the file just like it is in the source the sniff is based on.

bad errors claiming file docblock is a class docblock
https://travis-ci.org/photodude/coding-standards/jobs/202073691

corrected
https://travis-ci.org/photodude/coding-standards/jobs/202078903