### PR TITLE
[PHPCS2] add note to message adjustments Note: the autofixer will convert spaces to tabs

### DIFF
--- a/Joomla/ruleset.xml
+++ b/Joomla/ruleset.xml
@@ -83,7 +83,7 @@
 		<properties>
 			<property name="indent" value="4"/>
 		</properties>
-		<message>Multi-line function call not indented correctly; expected %s tabs but found %s</message>
+		<message>Multi-line function call not indented correctly; expected %s spaces but found %s. Note: the autofixer will convert spaces to tabs</message>
 	</rule>
 	<rule ref="PEAR.Functions.FunctionDeclaration">
 		<properties>
@@ -95,7 +95,7 @@
 		<properties>
 			<property name="indent" value="4"/>
 		</properties>
-		<message>Multi-line function declaration not indented correctly; expected %s tabs but found %s</message>
+		<message>Multi-line function declaration not indented correctly; expected %s spaces but found %s. Note: the autofixer will convert spaces to tabs</message>
 	</rule>
 	<rule ref="PEAR.Functions.ValidDefaultValue" />
 	<rule ref="PEAR.NamingConventions.ValidClassName" />

--- a/Joomla/ruleset.xml
+++ b/Joomla/ruleset.xml
@@ -69,7 +69,7 @@
 		<properties>
 			<property name="indent" value="4"/>
 		</properties>
-		<message>Multi-line IF statement not indented correctly; expected %s tabs but found %s</message>
+		<message>Multi-line IF statement not indented correctly; expected %s spaces but found %s. Note: the autofixer will convert spaces to tabs</message>
 	</rule>
 	<rule ref="PEAR.Formatting.MultiLineAssignment" />
 	<rule ref="PEAR.Functions.FunctionCallSignature">
@@ -108,7 +108,7 @@
 		<properties>
 			<property name="indent" value="4"/>
 		</properties>
-		<message>Object operator not indented correctly; expected %s tabs but found %s</message>
+		<message>Object operator not indented correctly; expected %s spaces but found %s. Note: the autofixer will convert spaces to tabs</message>
 	</rule>
 
 	<!-- Include some additional sniffs from the PSR2 standard -->
@@ -159,6 +159,9 @@
 		</properties>
 	</rule>
 	<rule ref="Squiz.WhiteSpace.ScopeClosingBrace" />
+	<rule ref="Squiz.WhiteSpace.ScopeClosingBrace.Indent">
+		   <message>Closing brace indented incorrectly; expected %s spaces, found %s. Note: the autofixer will convert spaces to tabs</message>
+	</rule>
 	<rule ref="Squiz.WhiteSpace.CastSpacing" />
 	<rule ref="Squiz.WhiteSpace.ControlStructureSpacing">
 		<exclude name="Squiz.WhiteSpace.ControlStructureSpacing.LineAfterClose" />


### PR DESCRIPTION
This covers the pear rules with adjusted messages to report spaces as tabs. This is a better solution without needing custom sniffs.  