### PR TITLE
fix documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repository includes the [Joomla](http://developer.joomla.org) coding standa
 
 See Joomla coding standards documentation at [http://joomla.github.io/coding-standards/](http://joomla.github.io/coding-standards/)
 
-If you want to contribute and improve this documentation find the source files at [https://github.com/joomla/coding-standards/tree/gh-pages](https://github.com/joomla/coding-standards/tree/gh-pages)
+If you want to contribute and improve this documentation, you can find the source files in the manual section of the master branch [https://github.com/joomla/coding-standards/tree/master/manual](https://github.com/joomla/coding-standards/tree/master/manual)
 
 ## Requirements
 


### PR DESCRIPTION
the gh-pages is no longer where the manual/documentation lives