### PR TITLE
Spacing After Comment fails to fix error when comment is not a docblock

### DIFF
--- a/Joomla/Sniffs/WhiteSpace/MemberVarSpacingSniff.php
+++ b/Joomla/Sniffs/WhiteSpace/MemberVarSpacingSniff.php
@@ -56,6 +56,12 @@ class Joomla_Sniffs_WhiteSpace_MemberVarSpacingSniff extends Squiz_Sniffs_WhiteS
 					{
 						$phpcsFile->fixer->beginChangeset();
 
+						// Inline comments have the newline included in the content but docblock do not.
+						if ($tokens[$prev]['code'] === T_COMMENT)
+						{
+							$phpcsFile->fixer->replaceToken($prev, rtrim($tokens[$prev]['content']));
+						}
+
 						for ($i = ($prev + 1); $i <= $stackPtr; $i++)
 						{
 							if ($tokens[$i]['line'] === $tokens[$stackPtr]['line'])


### PR DESCRIPTION
Fix from https://github.com/squizlabs/PHP_CodeSniffer/commit/0434c489d21e402199fb0b4ab581af5009cb706d
fix for https://github.com/squizlabs/PHP_CodeSniffer/issues/983