### PR TITLE
Fixes for False positive for function names starting with triple underscore

### DIFF
--- a/Joomla/Sniffs/NamingConventions/ValidFunctionNameSniff.php
+++ b/Joomla/Sniffs/NamingConventions/ValidFunctionNameSniff.php
@@ -45,7 +45,7 @@ class Joomla_Sniffs_NamingConventions_ValidFunctionNameSniff extends PEAR_Sniffs
 		$errorData = array($className . '::' . $methodName);
 
 		// Is this a magic method. i.e., is prefixed with "__" ?
-		if (preg_match('|^__|', $methodName) !== 0)
+		if (preg_match('|^__[^_]|', $methodName) !== 0)
 		{
 			$magicPart = strtolower(substr($methodName, 2));
 


### PR DESCRIPTION
Fix for https://github.com/squizlabs/PHP_CodeSniffer/pull/1240
Fix from  https://github.com/squizlabs/PHP_CodeSniffer/commit/6d3a03aa1e823fe6bfd16ef8f267133e790c4610