### PR TITLE
Update FunctionComment sniff with phpcs 2 fixes

### DIFF
--- a/Joomla/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/Joomla/Sniffs/Commenting/FunctionCommentSniff.php
@@ -201,7 +201,7 @@ class Joomla_Sniffs_Commenting_FunctionCommentSniff extends PEAR_Sniffs_Commenti
 
 				    if ($typeLen > $maxType)
 				    {
-					$maxType = $typeLen;
+						$maxType = $typeLen;
 				    }
 				}
 
@@ -272,14 +272,14 @@ class Joomla_Sniffs_Commenting_FunctionCommentSniff extends PEAR_Sniffs_Commenti
 		$previousParam = null;
 
 		/*
-		 * We want to use ... for all variable length arguments, 
+		 * We want to use ... for all variable length arguments,
 		 * so added this prefix to the variable name so comparisons are easier.
 		 */
 		foreach ($realParams as $pos => $param)
 		{
 			if ($param['variable_length'] === true)
 			{
-				$realParams[$pos]['name'] = '...'.$realParams[$pos]['name'];
+				$realParams[$pos]['name'] = '...' . $realParams[$pos]['name'];
 			}
 		}
 

--- a/Joomla/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/Joomla/Sniffs/Commenting/FunctionCommentSniff.php
@@ -186,7 +186,7 @@ class Joomla_Sniffs_Commenting_FunctionCommentSniff extends PEAR_Sniffs_Commenti
 			$var       = '';
 			$varSpace  = 0;
 			$comment   = '';
- 			$commentEnd = 0;
+			$commentEnd = 0;
 
 			if ($tokens[($tag + 2)]['code'] === T_DOC_COMMENT_STRING)
 			{
@@ -236,7 +236,7 @@ class Joomla_Sniffs_Commenting_FunctionCommentSniff extends PEAR_Sniffs_Commenti
 							if ($tokens[$i]['code'] === T_DOC_COMMENT_STRING)
 							{
 								$comment   .= ' ' . $tokens[$i]['content'];
-                                $commentEnd = $i;
+								$commentEnd = $i;
 							}
 						}
 					}

--- a/Joomla/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/Joomla/Sniffs/Commenting/FunctionCommentSniff.php
@@ -190,7 +190,7 @@ class Joomla_Sniffs_Commenting_FunctionCommentSniff extends PEAR_Sniffs_Commenti
 			if ($tokens[($tag + 2)]['code'] === T_DOC_COMMENT_STRING)
 			{
 				$matches = array();
-				preg_match('/([^$&]+)(?:((?:\$|&)[^\s]+)(?:(\s+)(.*))?)?/', $tokens[($tag + 2)]['content'], $matches);
+				preg_match('/([^$&.]+)(?:((?:\.\.\.)?(?:\$|&)[^\s]+)(?:(\s+)(.*))?)?/', $tokens[($tag + 2)]['content'], $matches);
 
 				$typeLen   = strlen($matches[1]);
 				$type      = trim($matches[1]);
@@ -267,6 +267,16 @@ class Joomla_Sniffs_Commenting_FunctionCommentSniff extends PEAR_Sniffs_Commenti
 		$realParams    = $phpcsFile->getMethodParameters($stackPtr);
 		$foundParams   = array();
 		$previousParam = null;
+
+		/*
+		 * We want to use ... for all variable length arguments, 
+		 * so added this prefix to the variable name so comparisons are easier.
+		 */
+		foreach ($realParams as $pos => $param) {
+			if ($param['variable_length'] === true) {
+				$realParams[$pos]['name'] = '...'.$realParams[$pos]['name'];
+			}
+		}
 
 		foreach ($params as $pos => $param)
 		{

--- a/Joomla/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/Joomla/Sniffs/Commenting/FunctionCommentSniff.php
@@ -192,14 +192,17 @@ class Joomla_Sniffs_Commenting_FunctionCommentSniff extends PEAR_Sniffs_Commenti
 				$matches = array();
 				preg_match('/([^$&.]+)(?:((?:\.\.\.)?(?:\$|&)[^\s]+)(?:(\s+)(.*))?)?/', $tokens[($tag + 2)]['content'], $matches);
 
-				$typeLen   = strlen($matches[1]);
-				$type      = trim($matches[1]);
-				$typeSpace = ($typeLen - strlen($type));
-				$typeLen   = strlen($type);
-
-				if ($typeLen > $maxType)
+				if (empty($matches) === false)
 				{
+				    $typeLen   = strlen($matches[1]);
+				    $type      = trim($matches[1]);
+				    $typeSpace = ($typeLen - strlen($type));
+				    $typeLen   = strlen($type);
+
+				    if ($typeLen > $maxType)
+				    {
 					$maxType = $typeLen;
+				    }
 				}
 
 				if (isset($matches[2]) === true)
@@ -272,8 +275,10 @@ class Joomla_Sniffs_Commenting_FunctionCommentSniff extends PEAR_Sniffs_Commenti
 		 * We want to use ... for all variable length arguments, 
 		 * so added this prefix to the variable name so comparisons are easier.
 		 */
-		foreach ($realParams as $pos => $param) {
-			if ($param['variable_length'] === true) {
+		foreach ($realParams as $pos => $param)
+		{
+			if ($param['variable_length'] === true)
+			{
 				$realParams[$pos]['name'] = '...'.$realParams[$pos]['name'];
 			}
 		}

--- a/Joomla/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/Joomla/Sniffs/Commenting/FunctionCommentSniff.php
@@ -186,6 +186,7 @@ class Joomla_Sniffs_Commenting_FunctionCommentSniff extends PEAR_Sniffs_Commenti
 			$var       = '';
 			$varSpace  = 0;
 			$comment   = '';
+ 			$commentEnd = 0;
 
 			if ($tokens[($tag + 2)]['code'] === T_DOC_COMMENT_STRING)
 			{
@@ -234,7 +235,8 @@ class Joomla_Sniffs_Commenting_FunctionCommentSniff extends PEAR_Sniffs_Commenti
 						{
 							if ($tokens[$i]['code'] === T_DOC_COMMENT_STRING)
 							{
-								$comment .= ' ' . $tokens[$i]['content'];
+								$comment   .= ' ' . $tokens[$i]['content'];
+                                $commentEnd = $i;
 							}
 						}
 					}
@@ -261,6 +263,7 @@ class Joomla_Sniffs_Commenting_FunctionCommentSniff extends PEAR_Sniffs_Commenti
 				'type'        => $type,
 				'var'         => $var,
 				'comment'     => $comment,
+				'comment_end' => $commentEnd,
 				'type_space'  => $typeSpace,
 				'var_space'   => $varSpace,
 				'align_space' => $tokens[($tag + 1)]['content']


### PR DESCRIPTION
- FunctionComment sniffs now support variadic functions
  -  Fix from https://github.com/squizlabs/PHP_CodeSniffer/commit/4966b545db497e038b3ba01fd21c0899be9365a9#diff-e366d95cd64d7200d6b59eca1b5e3093
  - Fix for https://github.com/squizlabs/PHP_CodeSniffer/issues/841
- FunctionComment sniffs now throw errors for some invalid `@param` lines