### PR TITLE
fix link again to be a link

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,4 +102,4 @@ The last most common adjustment is removing PHP 5.3 specific rules which prevent
 
 There is further information on how to set up IDE auto formatters here: 
 
-	https://github.com/joomla/coding-standards/tree/master/Joomla/IDE
+	[https://github.com/joomla/coding-standards/tree/master/Joomla/IDE](https://github.com/joomla/coding-standards/tree/master/Joomla/IDE)


### PR DESCRIPTION
Previous Link fix corrected the URL but didn't make it a link. this corrects that.

Fixes #172 