### PR TITLE
[phpcs-2] branch fix shortArraySyntax for class params

### DIFF
--- a/Joomla/Sniffs/Classes/InstantiateNewClassesSniff.php
+++ b/Joomla/Sniffs/Classes/InstantiateNewClassesSniff.php
@@ -100,7 +100,7 @@ class Joomla_Sniffs_Classes_InstantiateNewClassesSniff implements PHP_CodeSniffe
 						break;
 
 					case T_OPEN_SHORT_ARRAY :
-						if ($shortArraySyntax === true)
+						if ($this->shortArraySyntax === true)
 						{
 							if ($started === true)
 							{


### PR DESCRIPTION
This is just to make sure if someone is looking at this branch they don't get confused with this minor typo