### PR TITLE
Changed Composer package type to phpcodesniffer-standard

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "joomla/coding-standards",
-    "type": "library",
+    "type": "phpcodesniffer-standard",
     "description": "Joomla Coding Standards",
     "keywords": ["joomla", "coding standards", "phpcs", "php codesniffer"],
     "homepage": "https://github.com/joomla/coding-standards",


### PR DESCRIPTION
## Problem/Motivation

Composer allows declaring [the type of a package][composer-package-type]. When no 
type is declared, the default is "library".

There are various [composer plugins][composer-plugin] that can install custom
PHP CodeSniffer standards:

- https://github.com/DealerDirect/phpcodesniffer-composer-installer
- https://github.com/higidi/composer-phpcodesniffer-standards-plugin
- https://github.com/SimplyAdmire/ComposerPlugins

For these installers to work, the package type needs to be set to "phpcodesniffer-standard".

There are also [a lot of packages][phpcodesniffer-packages] that adhere to this type.

## Proposed changes

Changing the following line to the `composer.json` will make it possible for such packages to install this custom sniff using composer:

```json
    "type" : "phpcodesniffer-standard"
```

This will in _no way_ change the existing behaviour of this package for users that do not include one of the packages mentioned above in their projects `composer.json`.

## Possible future steps

- Update documentation
- Require an installer plugin by default
- Update Ant / Travis builds 

[composer-package-type]: https://getcomposer.org/doc/04-schema.md#type
[composer-plugin]: https://getcomposer.org/doc/articles/plugins.md
[phpcodesniffer-packages]: https://github.com/search?p=2&q=filename%3Acomposer.json+type+phpcodesniffer+standard&type=Code&utf8=%E2%9C%93