### PR TITLE
fix CS tabs use

### DIFF
--- a/Joomla/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/Joomla/Sniffs/Commenting/FunctionCommentSniff.php
@@ -195,15 +195,15 @@ class Joomla_Sniffs_Commenting_FunctionCommentSniff extends PEAR_Sniffs_Commenti
 
 				if (empty($matches) === false)
 				{
-				    $typeLen   = strlen($matches[1]);
-				    $type      = trim($matches[1]);
-				    $typeSpace = ($typeLen - strlen($type));
-				    $typeLen   = strlen($type);
+					$typeLen   = strlen($matches[1]);
+					$type      = trim($matches[1]);
+					$typeSpace = ($typeLen - strlen($type));
+					$typeLen   = strlen($type);
 
-				    if ($typeLen > $maxType)
-				    {
+					if ($typeLen > $maxType)
+					{
 						$maxType = $typeLen;
-				    }
+					}
 				}
 
 				if (isset($matches[2]) === true)


### PR DESCRIPTION
@mbabker looks like PHPCS 2.8 was missing these CS issues where spaces were mixed in PHPCS 2.9.x caught them