### PR TITLE
Proposal for rule to consistently use `&&` and `||` instead of `AND` and `OR` operators.

### DIFF
--- a/manual/php.md
+++ b/manual/php.md
@@ -143,6 +143,11 @@ catch (RuntimeException $e)
 	throw new Exception($e->getMessage(), 500, $e);
 }
 ```
+## Logical operators
+
+Logical operators `&&`, `||`, should be used instead of `AND` and `OR`. The reason behind this, is that they are not interchangeable 1-for-1 because of operator precedence (see: http://php.net/manual/en/language.operators.precedence.php).
+Parentheses should be used in order to explicitly group parts of an expression, if necessary. This rule is also true for template files.
+
 
 
 ## Mixed language usage (e.g. at the layout files)


### PR DESCRIPTION
As  discussed here: https://github.com/joomla/joomla-cms/pull/12233 - starting at review: https://github.com/joomla/joomla-cms/pull/12233#pullrequestreview-2379665, it is better to have a standard way to use logical operators - namely && and || -, instead of having the differently behaving `AND` and `OR`, especially in template files. This should put a correct standard in place.