### PR TITLE
clarify function space rules for function definition and closures

### DIFF
--- a/manual/php.md
+++ b/manual/php.md
@@ -256,7 +256,7 @@ $long   = bar('long');
 
 ## Function Definitions
 
-Function definitions start on a new line and the opening and closing braces are also placed on new lines. An empty line should precede lines specifying the return value.
+Function definitions start on a new line with no spaces between the function name and the opening parenthesis. Additionally, the opening and closing braces are also placed on new lines. An empty line should precede lines specifying the return value.
 
 Function definitions must include a documentation comment in accordance with the Commenting section of this document.
 More details on DocBlocks Function comments can be found in the chapter on [DocBlocks Comments](docblocks.md).

--- a/manual/php.md
+++ b/manual/php.md
@@ -290,6 +290,18 @@ function fooBar($param1, $param2,
 }
 ```
 
+## Closures / Anonymous functions
+Closures/Anonymous functions should have a space between the Closure's/Anonymous function's name and the opening parenthesis. Method signatures don't have the space.
+
+```php
+$fieldIds = array_map(
+	function ($f)
+	{
+		return $f->id;
+	},
+	$fields
+);
+```
 
 ## Class Definitions
 


### PR DESCRIPTION
no spaces between the function definition name and the opening parenthesis, same as example shows.

closures have a space between the name and opening parenthesis