### PR TITLE
We don't need to include PHPCS in composer.json instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ Add `"joomla/coding-standards": "~2.0"` to the require-dev block in your compose
 ```json
 {
     "require-dev": {
-		"squizlabs/php_codesniffer": "~2.8",
 		"joomla/coding-standards": "~2.0"
 	}
 }
@@ -38,7 +37,15 @@ composer require joomla/coding-standards "~2.0"
 ```
 
 As stability of joomla/coding-standards 2.0.0 is currently alpha, make sure you allow usage of alpha software in Composer:
-
+In Composer json
+```json
+{
+    "require-dev": {
+		"joomla/coding-standards": "~2.0@alpha"
+	}
+}
+```
+or on the command line
 ```bash
 composer property-set minimum-stability "alpha"
 ```


### PR DESCRIPTION
PHPCS is  included because of the coding standards requirements
also note the alpha install with composer.json