### PR TITLE
Make file package tag optional

### DIFF
--- a/Joomla/Sniffs/Commenting/FileCommentSniff.php
+++ b/Joomla/Sniffs/Commenting/FileCommentSniff.php
@@ -39,7 +39,7 @@ class Joomla_Sniffs_Commenting_FileCommentSniff implements PHP_CodeSniffer_Sniff
 										'order_text'     => 'precedes @package',
 										),
 						'@package'    => array(
-										'required'       => true,
+										'required'       => false,
 										'allow_multiple' => false,
 										'order_text'     => 'must follows @category (if used)',
 										),


### PR DESCRIPTION
As noted in #193 project wide we are at a state where repos and code are more dominantly in namespaces than not, so I think it's time to relax this requirement in the base coding standard.

For documentation purposes, our requirements should note that files containing non-namespaced classes (I think I would push it more toward that than a general "file without a namespace" statement as that affects procedural files like an `index.php`) should continue to require the tag and implementors create a custom ruleset (possibly a sniff too?) to enforce said requirement.