### PR TITLE
Add PHP 7.2 as allowed failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,10 @@ matrix:
     - php: 5.6
     - php: 7.0
     - php: 7.1
+    - php: 7.2
     - php: nightly
   allow_failures:
+    - php: 7.2
     - php: nightly
 
 before_script:


### PR DESCRIPTION
PHP 7.2 has been named as a branch.