### PR TITLE
Remove DisallowShortArraySyntax in version 3

### DIFF
--- a/Joomla/ExampleRulesets/Joomla-Stats/ruleset.xml
+++ b/Joomla/ExampleRulesets/Joomla-Stats/ruleset.xml
@@ -26,9 +26,4 @@
         <exclude name="Generic.Arrays.DisallowShortArraySyntax"/>
     </rule>
 
-    <rule ref="Joomla.Classes.InstantiateNewClasses">
-        <properties>
-            <property name="shortArraySyntax" value="true"/>
-        </properties>
-    </rule>
 </ruleset>

--- a/Joomla/ExampleRulesets/Joomla-Stats/ruleset.xml
+++ b/Joomla/ExampleRulesets/Joomla-Stats/ruleset.xml
@@ -23,7 +23,6 @@
         <exclude name="Joomla.NamingConventions.ValidVariableName.MemberNotCamelCaps"/>
         <exclude name="Joomla.NamingConventions.ValidVariableName.NotCamelCaps"/>
         <exclude name="Joomla.NamingConventions.ValidFunctionName.ScopeNotCamelCaps"/>
-        <exclude name="Generic.Arrays.DisallowShortArraySyntax"/>
     </rule>
 
 </ruleset>

--- a/Joomla/ExampleRulesets/README.md
+++ b/Joomla/ExampleRulesets/README.md
@@ -39,3 +39,12 @@ Old Protected method names were at one time prefixed with an underscore. These P
   <exclude name="Joomla.NamingConventions.ValidVariableName.ClassVarHasUnderscore"/>
  </rule>
 ```
+
+## Using example rulesets that Selectively Applying Rule
+You have to tell you can tell PHPCS where the example ruleset folder is (i.e. install them in PHPCS)
+```sh
+phpcs --config-set installed_paths /path/to/joomla/coding-standards/Example-Rulesets
+```
+Note: the composer scripts will run when the standard is installed globally, but not when it's a dependancy. As such, you may want to run PHPCS config-set. When you run PHPCS config-set it will always overwrite the previous values. Use `--config-show` to check previous values before using `--config-set`
+So instead of overwriting the existing paths you should copy the existing paths revealed with `--config-show` and add each one seperated by a comma:
+`phpcs --config-set installed_paths [path_1],[path_2],[/path/to/joomla-coding-standards],[/path/to/joomla/coding-standards/Example-Rulesets]`

--- a/Joomla/ExampleRulesets/README.md
+++ b/Joomla/ExampleRulesets/README.md
@@ -39,17 +39,3 @@ Old Protected method names were at one time prefixed with an underscore. These P
   <exclude name="Joomla.NamingConventions.ValidVariableName.ClassVarHasUnderscore"/>
  </rule>
 ```
-
-The last most common adjustment is removing PHP 5.3 specific rules which prevent short array syntax, and allowing short array syntax for method parameters.
-
-```xml
- <rule ref="Generic">
-  <exclude name="Generic.Arrays.DisallowShortArraySyntax"/>
- </rule>
- <rule ref="Joomla.Classes.InstantiateNewClasses">
-   <properties>
-     <property name="shortArraySyntax" value="true"/>
-   </properties>
- </rule>
- 
-```

--- a/Joomla/Sniffs/Classes/InstantiateNewClassesSniff.php
+++ b/Joomla/Sniffs/Classes/InstantiateNewClassesSniff.php
@@ -18,14 +18,6 @@ use PHP_CodeSniffer\Files\File;
 class InstantiateNewClassesSniff implements Sniff
 {
 	/**
-	 * If true, short Array Syntax for php 5.4+ will be allow for Instantiating New Classes if they are found in the code.
-	 * this should be removed when all Joomla projects no longer need to support php 5.3
-	 *
-	 * @var boolean
-	 */
-	public $shortArraySyntax = false;
-
-	/**
 	 * Registers the token types that this sniff wishes to listen to.
 	 *
 	 * @return  array
@@ -103,13 +95,10 @@ class InstantiateNewClassesSniff implements Sniff
 						break;
 
 					case T_OPEN_SHORT_ARRAY :
-						if ($this->shortArraySyntax === true)
+						if ($started === true)
 						{
-							if ($started === true)
-							{
-								$valid   = true;
-								$running = false;
-							}
+							$valid   = true;
+							$running = false;
 						}
 						break;
 				}

--- a/Joomla/ruleset.xml
+++ b/Joomla/ruleset.xml
@@ -10,7 +10,6 @@
 	<!-- Include all sniffs in an external standard directory -->
 
 	<!-- Include some additional sniffs from the Generic standard -->
-	<rule ref="Generic.Arrays.DisallowShortArraySyntax" />
 	<rule ref="Generic.ControlStructures.InlineControlStructure" />
 	<rule ref="Generic.Files.EndFileNewline" />
 

--- a/README.md
+++ b/README.md
@@ -104,19 +104,6 @@ Old Protected method names were at one time prefixed with an underscore. These P
  </rule>
 ```
 
-The last most common adjustment is removing PHP 5.3 specific rules which prevent short array syntax, and allowing short array syntax for method parameters.
-
-```xml
- <rule ref="Generic">
-  <exclude name="Generic.Arrays.DisallowShortArraySyntax"/>
- </rule>
- <rule ref="Joomla.Classes.InstantiateNewClasses">
-   <properties>
-     <property name="shortArraySyntax" value="true"/>
-   </properties>
- </rule>
- 
-```
 ## Using example rulesets that Selectively Applying Rule
 You have to tell you can tell PHPCS where the example ruleset folder is (i.e. install them in PHPCS)
 ```sh


### PR DESCRIPTION
Since version 3 of the code style is PHP5.4+ we do not need to exclude the use of short array syntax as we are not supporting PHP 5.3 with version 3.
In the future, we may enforce DisallowLongArraySyntax, but for now version 3 should allow both.