### PR TITLE
One indenting sniff to rule them all

### DIFF
--- a/Joomla/Sniffs/ControlStructures/ControlStructuresBracketsSniff.php
+++ b/Joomla/Sniffs/ControlStructures/ControlStructuresBracketsSniff.php
@@ -59,6 +59,7 @@ class Joomla_Sniffs_ControlStructures_ControlStructuresBracketsSniff implements 
 				$error = 'Possible parse error: %s missing opening or closing brace';
 				$phpcsFile->addWarning($error, $stackPtr, 'MissingBrace', $errorData);
 			}
+
 			return;
 		}
 

--- a/Joomla/Sniffs/ControlStructures/ControlStructuresBracketsSniff.php
+++ b/Joomla/Sniffs/ControlStructures/ControlStructuresBracketsSniff.php
@@ -24,7 +24,6 @@ class Joomla_Sniffs_ControlStructures_ControlStructuresBracketsSniff implements 
 	 */
 	public $indent = 4;
 
-
 	/**
 	 * Returns an array of tokens this test wants to listen for.
 	 *

--- a/Joomla/Sniffs/ControlStructures/ControlStructuresBracketsSniff.php
+++ b/Joomla/Sniffs/ControlStructures/ControlStructuresBracketsSniff.php
@@ -143,67 +143,6 @@ class Joomla_Sniffs_ControlStructures_ControlStructuresBracketsSniff implements 
 			}
 		}
 
-		if ($tokens[($openBrace - 1)]['code'] === T_WHITESPACE)
-		{
-			$prevContent = $tokens[($openBrace - 1)]['content'];
-
-			if ($prevContent === $phpcsFile->eolChar)
-			{
-				$spaces = 0;
-			}
-			else
-			{
-				$blankSpace = substr($prevContent, strpos($prevContent, $phpcsFile->eolChar));
-				$spaces = 0;
-
-				/**
-				 * A tab is only counted with strlen as 1 character but we want to count
-				 * the number of spaces so add 4 characters for a tab otherwise the strlen
-				 */
-				for ($i = 0; $length = strlen($blankSpace), $i < $length; $i++)
-				{
-					if ($blankSpace[$i] === "\t")
-					{
-						$spaces += $this->indent;
-					}
-					else
-					{
-						$spaces += strlen($blankSpace[$i]);
-					}
-				}
-			}
-
-			$expected = ($tokens[$stackPtr]['level'] * ($this->indent));
-
-			// We need to divide by 4 here since there is a space vs tab intent in the check vs token
-			$expected /= $this->indent;
-			$spaces   /= $this->indent;
-
-			if ($spaces !== $expected)
-			{
-				$error = 'Expected %s tabs before opening brace; %s found';
-				$data  = array(
-						  $expected,
-						  $spaces,
-						 );
-				$fix   = $phpcsFile->addFixableError($error, $openBrace, 'SpaceBeforeBrace', $data);
-
-				if ($fix === true)
-				{
-					$indent = str_repeat("\t", $expected);
-
-					if ($spaces === 0)
-					{
-						$phpcsFile->fixer->addContentBefore($openBrace, $indent);
-					}
-					else
-					{
-						$phpcsFile->fixer->replaceToken(($openBrace - 1), $indent);
-					}
-				}
-			}
-		}
-
 		// A single newline after opening brace (i.e. brace in on a line by itself), remove extra newlines.
 		if (isset($tokens[$stackPtr]['scope_opener']) === true)
 		{

--- a/Joomla/Sniffs/ControlStructures/ControlStructuresBracketsSniff.php
+++ b/Joomla/Sniffs/ControlStructures/ControlStructuresBracketsSniff.php
@@ -18,13 +18,6 @@
 class Joomla_Sniffs_ControlStructures_ControlStructuresBracketsSniff implements PHP_CodeSniffer_Sniff
 {
 	/**
-	 * The number of spaces code should be indented.
-	 *
-	 * @var integer
-	 */
-	public $indent = 4;
-
-	/**
 	 * Returns an array of tokens this test wants to listen for.
 	 *
 	 * @return array

--- a/Joomla/Sniffs/ControlStructures/ControlStructuresBracketsSniff.php
+++ b/Joomla/Sniffs/ControlStructures/ControlStructuresBracketsSniff.php
@@ -52,14 +52,9 @@ class Joomla_Sniffs_ControlStructures_ControlStructuresBracketsSniff implements 
 		$tokens    = $phpcsFile->getTokens();
 		$errorData = array(strtolower($tokens[$stackPtr]['content']));
 
+		// If no scope opener return, other rules will address that issue
 		if (isset($tokens[$stackPtr]['scope_opener']) === false)
 		{
-			if ($tokens[$stackPtr]['code'] !== T_WHILE)
-			{
-				$error = 'Possible parse error: %s missing opening or closing brace';
-				$phpcsFile->addWarning($error, $stackPtr, 'MissingBrace', $errorData);
-			}
-
 			return;
 		}
 

--- a/Joomla/Sniffs/ControlStructures/ControlStructuresBracketsSniff.php
+++ b/Joomla/Sniffs/ControlStructures/ControlStructuresBracketsSniff.php
@@ -56,20 +56,8 @@ class Joomla_Sniffs_ControlStructures_ControlStructuresBracketsSniff implements 
 	 */
 	public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
 	{
-		$tokens    = $phpcsFile->getTokens();
-		$errorData = array(strtolower($tokens[$stackPtr]['content']));
-
-		if (isset($tokens[$stackPtr]['scope_opener']) === false)
-		{
-			if ($tokens[$stackPtr]['code'] !== T_WHILE)
-			{
-				$error = 'Possible parse error: %s missing opening or closing brace';
-				$phpcsFile->addWarning($error, $stackPtr, 'MissingBrace', $errorData);
-			}
-
-			return;
-		}
-
+		$tokens               = $phpcsFile->getTokens();
+		$errorData            = array(strtolower($tokens[$stackPtr]['content']));
 		$openBrace            = $tokens[$stackPtr]['scope_opener'];
 		$lastContent          = $phpcsFile->findPrevious(T_WHITESPACE, ($openBrace - 1), $stackPtr, true);
 		$controlStructureLine = $tokens[$lastContent]['line'];

--- a/Joomla/Sniffs/ControlStructures/ControlStructuresBracketsSniff.php
+++ b/Joomla/Sniffs/ControlStructures/ControlStructuresBracketsSniff.php
@@ -49,8 +49,15 @@ class Joomla_Sniffs_ControlStructures_ControlStructuresBracketsSniff implements 
 	 */
 	public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
 	{
-		$tokens               = $phpcsFile->getTokens();
-		$errorData            = array(strtolower($tokens[$stackPtr]['content']));
+		$tokens    = $phpcsFile->getTokens();
+		$errorData = array(strtolower($tokens[$stackPtr]['content']));
+
+		// If there is no scope opener skip this sniff
+		if (isset($tokens[$stackPtr]['scope_opener']) === false)
+		{
+			return;
+		}
+
 		$openBrace            = $tokens[$stackPtr]['scope_opener'];
 		$lastContent          = $phpcsFile->findPrevious(T_WHITESPACE, ($openBrace - 1), $stackPtr, true);
 		$controlStructureLine = $tokens[$lastContent]['line'];

--- a/Joomla/Sniffs/ControlStructures/ControlStructuresBracketsSniff.php
+++ b/Joomla/Sniffs/ControlStructures/ControlStructuresBracketsSniff.php
@@ -52,9 +52,13 @@ class Joomla_Sniffs_ControlStructures_ControlStructuresBracketsSniff implements 
 		$tokens    = $phpcsFile->getTokens();
 		$errorData = array(strtolower($tokens[$stackPtr]['content']));
 
-		// If there is no scope opener skip this sniff
 		if (isset($tokens[$stackPtr]['scope_opener']) === false)
 		{
+			if ($tokens[$stackPtr]['code'] !== T_WHILE)
+			{
+				$error = 'Possible parse error: %s missing opening or closing brace';
+				$phpcsFile->addWarning($error, $stackPtr, 'MissingBrace', $errorData);
+			}
 			return;
 		}
 

--- a/Joomla/Tests/ControlStructures/ControlStructuresBracketsUnitTest.inc
+++ b/Joomla/Tests/ControlStructures/ControlStructuresBracketsUnitTest.inc
@@ -22,30 +22,6 @@ if ($a)
 {echo true;
 }
 
-if ($a)
-     {
-	echo true;
-}
-
-function muh()
-{
-	if ($a)
-		{
-		echo true;
-	}
-
-	if ($a)
-{
-		echo true;
-	}
-
-	// If statement with spaces which aren't equal to a tab space (4 spaces)
-	if ($a)
-	  {
-		echo true;
-	}
-}
-
 // NewlineAfterOpenBrace
 if ($a)
 {

--- a/Joomla/Tests/ControlStructures/ControlStructuresBracketsUnitTest.inc.fixed
+++ b/Joomla/Tests/ControlStructures/ControlStructuresBracketsUnitTest.inc.fixed
@@ -23,30 +23,6 @@ if ($a)
 echo true;
 }
 
-if ($a)
-{
-	echo true;
-}
-
-function muh()
-{
-	if ($a)
-	{
-		echo true;
-	}
-
-	if ($a)
-	{
-		echo true;
-	}
-
-	// If statement with spaces which aren't equal to a tab space (4 spaces)
-	if ($a)
-	{
-		echo true;
-	}
-}
-
 // NewlineAfterOpenBrace
 if ($a)
 {

--- a/Joomla/Tests/ControlStructures/ControlStructuresBracketsUnitTest.php
+++ b/Joomla/Tests/ControlStructures/ControlStructuresBracketsUnitTest.php
@@ -36,4 +36,17 @@ class Joomla_Tests_ControlStructures_ControlStructuresBracketsUnitTest extends A
 				57 => 1,
 			   );
 	}
+
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * The key of the array should represent the line number and the value
+	 * should represent the number of warnings that should occur on that line.
+	 *
+	 * @return array<int, int>
+	 */
+	public function getWarningList()
+	{
+		return array();
+	}
 }

--- a/Joomla/Tests/ControlStructures/ControlStructuresBracketsUnitTest.php
+++ b/Joomla/Tests/ControlStructures/ControlStructuresBracketsUnitTest.php
@@ -28,10 +28,6 @@ class Joomla_Tests_ControlStructures_ControlStructuresBracketsUnitTest extends A
 				10  => 1,
 				16 => 1,
 				22 => 1,
-				26 => 1,
-				33 => 1,
-				38 => 1,
-				44 => 1,
 				51 => 1,
 				57 => 1,
 			   );

--- a/Joomla/Tests/ControlStructures/ControlStructuresBracketsUnitTest.php
+++ b/Joomla/Tests/ControlStructures/ControlStructuresBracketsUnitTest.php
@@ -36,17 +36,4 @@ class Joomla_Tests_ControlStructures_ControlStructuresBracketsUnitTest extends A
 				57 => 1,
 			   );
 	}
-
-	/**
-	 * Returns the lines where warnings should occur.
-	 *
-	 * The key of the array should represent the line number and the value
-	 * should represent the number of warnings that should occur on that line.
-	 *
-	 * @return array<int, int>
-	 */
-	public function getWarningList()
-	{
-		return array(6 => 1,);
-	}
 }

--- a/Joomla/Tests/ControlStructures/ControlStructuresBracketsUnitTest.php
+++ b/Joomla/Tests/ControlStructures/ControlStructuresBracketsUnitTest.php
@@ -28,8 +28,8 @@ class Joomla_Tests_ControlStructures_ControlStructuresBracketsUnitTest extends A
 				10  => 1,
 				16 => 1,
 				22 => 1,
-				51 => 1,
-				57 => 1,
+				27 => 1,
+				33 => 1,
 			   );
 	}
 

--- a/Joomla/ruleset.xml
+++ b/Joomla/ruleset.xml
@@ -78,24 +78,14 @@
 		</properties>
 		<exclude name="PEAR.Functions.FunctionDeclaration.BraceOnNewLine" />
 		<exclude name="PEAR.Functions.FunctionCallSignature.ContentAfterOpenBracket" />
-	</rule>
-	<rule ref="PEAR.Functions.FunctionCallSignature.Indent">
-		<properties>
-			<property name="indent" value="4"/>
-		</properties>
-		<message>Multi-line function call not indented correctly; expected %s spaces but found %s. Note: the autofixer will convert spaces to tabs</message>
+		<exclude name="PEAR.Functions.FunctionCallSignature.Indent" />
 	</rule>
 	<rule ref="PEAR.Functions.FunctionDeclaration">
 		<properties>
 			<property name="indent" value="4"/>
 		</properties>
 		<exclude name="PEAR.Functions.FunctionDeclaration.NewlineBeforeOpenBrace" />
-	</rule>
-	<rule ref="PEAR.Functions.FunctionDeclaration.Indent">
-		<properties>
-			<property name="indent" value="4"/>
-		</properties>
-		<message>Multi-line function declaration not indented correctly; expected %s spaces but found %s. Note: the autofixer will convert spaces to tabs</message>
+		<exclude name="PEAR.Functions.FunctionDeclaration.Indent" />
 	</rule>
 	<rule ref="PEAR.Functions.ValidDefaultValue" />
 	<rule ref="PEAR.NamingConventions.ValidClassName" />
@@ -158,9 +148,8 @@
 			<property name="ignoreNewlines" value="true" />
 		</properties>
 	</rule>
-	<rule ref="Squiz.WhiteSpace.ScopeClosingBrace" />
-	<rule ref="Squiz.WhiteSpace.ScopeClosingBrace.Indent">
-		   <message>Closing brace indented incorrectly; expected %s spaces, found %s. Note: the autofixer will convert spaces to tabs</message>
+	<rule ref="Squiz.WhiteSpace.ScopeClosingBrace">
+		<exclude name="Squiz.WhiteSpace.ScopeClosingBrace.Indent" />
 	</rule>
 	<rule ref="Squiz.WhiteSpace.CastSpacing" />
 	<rule ref="Squiz.WhiteSpace.ControlStructureSpacing">


### PR DESCRIPTION
We have some indenting issues related to our custom sniffs See #206 
let Generic.WhiteSpace.ScopeIndent do indenting, why should we do extra work for indenting when one core sniff already does the work for us. 

This PR works at eliminating indent duplication in the full ruleset. Bonus Time: we get rid of some awkward custom sniff messages about space indenting.

One indenting sniff to rule them all, One indenting sniff to find them; One indenting sniff to bring them all and in the darkness fix them.