### PR TITLE
Workaround for vscode ikappas.phpcs on PHPCS 2.9.1

### DIFF
--- a/Joomla/ruleset.xml
+++ b/Joomla/ruleset.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0"?>
 <ruleset name="Joomla">
 	<description>The Joomla coding standard.</description>
+	
+	<!-- Workaround for vscode ikappas.phpcs on PHPCS 2.9.1 -->
+	<arg value="q"/>
 
 	<!-- hard-code command line values into the standard to fix tabs vs spaces issue, etc -->
 	<arg name="tab-width" value="4"/>


### PR DESCRIPTION

PHPCS generates a progress output along the errors report. 

This modification forces the quiet mode and avoids error: "phpcs: Unexpected token F in JSON at position 0".

This issue is specific of vscode. So, I'm not sure if it's OK to accept this PR in general, just in case I'm sending the PR.
