### PR TITLE
Fix return type comments

### DIFF
--- a/Joomla/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/Joomla/Sniffs/Commenting/FunctionCommentSniff.php
@@ -146,17 +146,17 @@ class Joomla_Sniffs_Commenting_FunctionCommentSniff extends PEAR_Sniffs_Commenti
 						for ($returnToken = $stackPtr; $returnToken < $endToken; $returnToken++)
 						{
 							if ($tokens[$returnToken]['code'] === T_CLOSURE
-							|| $tokens[$returnToken]['code'] === T_ANON_CLASS
-							)
+								|| $tokens[$returnToken]['code'] === T_ANON_CLASS
+								)
 							{
 								$returnToken = $tokens[$returnToken]['scope_closer'];
 								continue;
 							}
 
 							if ($tokens[$returnToken]['code'] === T_RETURN
-							|| $tokens[$returnToken]['code'] === T_YIELD
-							|| $tokens[$returnToken]['code'] === T_YIELD_FROM
-							)
+								|| $tokens[$returnToken]['code'] === T_YIELD
+								|| $tokens[$returnToken]['code'] === T_YIELD_FROM
+								)
 							{
 								break;
 							}
@@ -181,20 +181,21 @@ class Joomla_Sniffs_Commenting_FunctionCommentSniff extends PEAR_Sniffs_Commenti
 					if (isset($tokens[$stackPtr]['scope_closer']) === true)
 					{
 						$endToken = $tokens[$stackPtr]['scope_closer'];
+
 						for ($returnToken = $stackPtr; $returnToken < $endToken; $returnToken++)
 						{
 							if ($tokens[$returnToken]['code'] === T_CLOSURE
-							|| $tokens[$returnToken]['code'] === T_ANON_CLASS
-							)
+								|| $tokens[$returnToken]['code'] === T_ANON_CLASS
+								)
 							{
 								$returnToken = $tokens[$returnToken]['scope_closer'];
 								continue;
 							}
 
 							if ($tokens[$returnToken]['code'] === T_RETURN
-							|| $tokens[$returnToken]['code'] === T_YIELD
-							|| $tokens[$returnToken]['code'] === T_YIELD_FROM
-							)
+								|| $tokens[$returnToken]['code'] === T_YIELD
+								|| $tokens[$returnToken]['code'] === T_YIELD_FROM
+								)
 							{
 								break;
 							}

--- a/Joomla/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/Joomla/Sniffs/Commenting/FunctionCommentSniff.php
@@ -82,8 +82,18 @@ class Joomla_Sniffs_Commenting_FunctionCommentSniff extends PEAR_Sniffs_Commenti
 			}
 			else
 			{
+				// Support both a return type and a description.
+				preg_match('`^((?:\|?(?:array\([^\)]*\)|[\\\\a-z0-9\[\]]+))*)( .*)?`i', $content, $returnParts);
+
+				if (isset($returnParts[1]) === false)
+				{
+					return;
+				}
+
+				$returnType = $returnParts[1];
+
 				// Check return type (can have multiple return types separated by '|').
-				$typeNames      = explode('|', $content);
+				$typeNames      = explode('|', $returnType);
 				$suggestedNames = array();
 
 				foreach ($typeNames as $i => $typeName)
@@ -98,19 +108,27 @@ class Joomla_Sniffs_Commenting_FunctionCommentSniff extends PEAR_Sniffs_Commenti
 
 				$suggestedType = implode('|', $suggestedNames);
 
-				if ($content !== $suggestedType)
+				if ($returnType !== $suggestedType)
 				{
 					$error = 'Expected "%s" but found "%s" for function return type';
 					$data  = array(
 						$suggestedType,
-						$content
+						$returnType
 					);
 
 					$fix = $phpcsFile->addFixableError($error, $return, 'InvalidReturn', $data);
 
 					if ($fix === true)
 					{
-						$phpcsFile->fixer->replaceToken(($return + 2), $suggestedType);
+						$replacement = $suggestedType;
+
+						if (empty($returnParts[2]) === false)
+						{
+							$replacement .= $returnParts[2];
+						}
+
+						$phpcsFile->fixer->replaceToken(($return + 2), $replacement);
+						unset($replacement);
 					}
 				}
 
@@ -119,14 +137,69 @@ class Joomla_Sniffs_Commenting_FunctionCommentSniff extends PEAR_Sniffs_Commenti
 				 * somewhere in the function that returns something.
 				 * Skip this check for mixed return types.
 				 */
-				if (!in_array($content, array('void', 'mixed')))
+				if ($returnType === 'void')
 				{
 					if (isset($tokens[$stackPtr]['scope_closer']) === true)
 					{
-						$endToken    = $tokens[$stackPtr]['scope_closer'];
-						$returnToken = $phpcsFile->findNext(array(T_RETURN, T_YIELD), $stackPtr, $endToken);
+						$endToken = $tokens[$stackPtr]['scope_closer'];
 
-						if ($returnToken === false)
+						for ($returnToken = $stackPtr; $returnToken < $endToken; $returnToken++) {
+							if ($tokens[$returnToken]['code'] === T_CLOSURE
+								|| $tokens[$returnToken]['code'] === T_ANON_CLASS
+								)
+							{
+								$returnToken = $tokens[$returnToken]['scope_closer'];
+								continue;
+							}
+
+							if ($tokens[$returnToken]['code'] === T_RETURN
+								|| $tokens[$returnToken]['code'] === T_YIELD
+								|| $tokens[$returnToken]['code'] === T_YIELD_FROM
+								)
+							{
+								break;
+							}
+						}
+
+						if ($returnToken !== $endToken)
+						{
+							// If the function is not returning anything, just exiting, then there is no problem.
+							$semicolon = $phpcsFile->findNext(T_WHITESPACE, ($returnToken + 1), null, true);
+
+							if ($tokens[$semicolon]['code'] !== T_SEMICOLON)
+							{
+								$error = 'Function return type is void, but function contains return statement';
+								$phpcsFile->addError($error, $return, 'InvalidReturnVoid');
+							}
+						}
+					}//end if
+				}
+				elseif ($returnType !== 'mixed' && in_array('void', $typeNames, true) === false)
+				{
+					// If return type is not void, there needs to be a return statement somewhere in the function that returns something.
+					if (isset($tokens[$stackPtr]['scope_closer']) === true)
+					{
+						$endToken = $tokens[$stackPtr]['scope_closer'];
+						for ($returnToken = $stackPtr; $returnToken < $endToken; $returnToken++)
+						{
+							if ($tokens[$returnToken]['code'] === T_CLOSURE
+								|| $tokens[$returnToken]['code'] === T_ANON_CLASS
+								)
+							{
+								$returnToken = $tokens[$returnToken]['scope_closer'];
+								continue;
+							}
+
+							if ($tokens[$returnToken]['code'] === T_RETURN
+								|| $tokens[$returnToken]['code'] === T_YIELD
+								|| $tokens[$returnToken]['code'] === T_YIELD_FROM
+								)
+							{
+								break;
+							}
+						}
+
+						if ($returnToken === $endToken)
 						{
 							$error = 'Function return type is not void, but function has no return statement';
 							$phpcsFile->addError($error, $return, 'InvalidNoReturn');

--- a/Joomla/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/Joomla/Sniffs/Commenting/FunctionCommentSniff.php
@@ -143,19 +143,20 @@ class Joomla_Sniffs_Commenting_FunctionCommentSniff extends PEAR_Sniffs_Commenti
 					{
 						$endToken = $tokens[$stackPtr]['scope_closer'];
 
-						for ($returnToken = $stackPtr; $returnToken < $endToken; $returnToken++) {
+						for ($returnToken = $stackPtr; $returnToken < $endToken; $returnToken++)
+						{
 							if ($tokens[$returnToken]['code'] === T_CLOSURE
-								|| $tokens[$returnToken]['code'] === T_ANON_CLASS
-								)
+							|| $tokens[$returnToken]['code'] === T_ANON_CLASS
+							)
 							{
 								$returnToken = $tokens[$returnToken]['scope_closer'];
 								continue;
 							}
 
 							if ($tokens[$returnToken]['code'] === T_RETURN
-								|| $tokens[$returnToken]['code'] === T_YIELD
-								|| $tokens[$returnToken]['code'] === T_YIELD_FROM
-								)
+							|| $tokens[$returnToken]['code'] === T_YIELD
+							|| $tokens[$returnToken]['code'] === T_YIELD_FROM
+							)
 							{
 								break;
 							}
@@ -183,17 +184,17 @@ class Joomla_Sniffs_Commenting_FunctionCommentSniff extends PEAR_Sniffs_Commenti
 						for ($returnToken = $stackPtr; $returnToken < $endToken; $returnToken++)
 						{
 							if ($tokens[$returnToken]['code'] === T_CLOSURE
-								|| $tokens[$returnToken]['code'] === T_ANON_CLASS
-								)
+							|| $tokens[$returnToken]['code'] === T_ANON_CLASS
+							)
 							{
 								$returnToken = $tokens[$returnToken]['scope_closer'];
 								continue;
 							}
 
 							if ($tokens[$returnToken]['code'] === T_RETURN
-								|| $tokens[$returnToken]['code'] === T_YIELD
-								|| $tokens[$returnToken]['code'] === T_YIELD_FROM
-								)
+							|| $tokens[$returnToken]['code'] === T_YIELD
+							|| $tokens[$returnToken]['code'] === T_YIELD_FROM
+							)
 							{
 								break;
 							}

--- a/Joomla/Tests/Commenting/FunctionCommentUnitTest.inc
+++ b/Joomla/Tests/Commenting/FunctionCommentUnitTest.inc
@@ -197,57 +197,57 @@ class MyClass
 	{
 		return 2;
 	}
-}
 
-/**
- * Get the details list of keys for a table.
- *
- * @param   array  $keys  An array of objects that comprise the keys for the table.
- *
- * @return  array  The lookup array. array({key name} => array(object, ...))
- *
- * @since   1.0
- */
-protected function getKeyLookup($keys)
-{
-	// First pass, create a lookup of the keys.
-	$lookup = array();
-
-	return $lookup;
-}
-
-/**
- * Test function ArrayWithClosure
- *
- * @return array
- */
-function returnArrayWithClosure()
-{
-    function ()
+	/**
+	 * Get the details list of keys for a table.
+	 *
+	 * @param   array  $keys  An array of objects that comprise the keys for the table.
+	 *
+	 * @return  array  The lookup array. array({key name} => array(object, ...))
+	 *
+	 * @since   1.0
+	 */
+	protected function getKeyLookup($keys)
 	{
-        return;
-    };
+		// First pass, create a lookup of the keys.
+		$lookup = array();
 
-    return array();
-}
+		return $lookup;
+	}
 
-/**
- * Test function ArrayWithAnonymousClass
- *
- * @return array
- */
-function returnArrayWithAnonymousClass()
-{
-    new class
+	/**
+	 * Test function ArrayWithClosure
+	 *
+	 * @return array
+	 */
+	function returnArrayWithClosure()
 	{
-        /**
-         * @return void
-         */
-        public function test()
+	    function ()
 		{
-            return;
-        }
-    };
+		return;
+	    };
 
-    return array();
+	    return array();
+	}
+
+	/**
+	 * Test function ArrayWithAnonymousClass
+	 *
+	 * @return array
+	 */
+	function returnArrayWithAnonymousClass()
+	{
+	    new class
+		{
+		/**
+		 * @return void
+		 */
+		public function test()
+			{
+		    return;
+		}
+	    };
+
+	    return array();
+	}
 }

--- a/Joomla/Tests/Commenting/FunctionCommentUnitTest.inc
+++ b/Joomla/Tests/Commenting/FunctionCommentUnitTest.inc
@@ -198,3 +198,56 @@ class MyClass
 		return 2;
 	}
 }
+
+/**
+ * Get the details list of keys for a table.
+ *
+ * @param   array  $keys  An array of objects that comprise the keys for the table.
+ *
+ * @return  array  The lookup array. array({key name} => array(object, ...))
+ *
+ * @since   1.0
+ */
+protected function getKeyLookup($keys)
+{
+	// First pass, create a lookup of the keys.
+	$lookup = array();
+
+	return $lookup;
+}
+
+/**
+ * Test function ArrayWithClosure
+ *
+ * @return array
+ */
+function returnArrayWithClosure()
+{
+    function ()
+	{
+        return;
+    };
+
+    return array();
+}
+
+/**
+ * Test function ArrayWithAnonymousClass
+ *
+ * @return array
+ */
+function returnArrayWithAnonymousClass()
+{
+    new class
+	{
+        /**
+         * @return void
+         */
+        public function test()
+		{
+            return;
+        }
+    };
+
+    return array();
+}

--- a/Joomla/Tests/Commenting/FunctionCommentUnitTest.inc.fixed
+++ b/Joomla/Tests/Commenting/FunctionCommentUnitTest.inc.fixed
@@ -197,4 +197,57 @@ class MyClass
 	{
 		return 2;
 	}
+
+	/**
+	 * Get the details list of keys for a table.
+	 *
+	 * @param   array  $keys  An array of objects that comprise the keys for the table.
+	 *
+	 * @return  array  The lookup array. array({key name} => array(object, ...))
+	 *
+	 * @since   1.0
+	 */
+	protected function getKeyLookup($keys)
+	{
+		// First pass, create a lookup of the keys.
+		$lookup = array();
+
+		return $lookup;
+	}
+
+	/**
+	 * Test function ArrayWithClosure
+	 *
+	 * @return array
+	 */
+	function returnArrayWithClosure()
+	{
+	    function ()
+		{
+		return;
+	    };
+
+	    return array();
+	}
+
+	/**
+	 * Test function ArrayWithAnonymousClass
+	 *
+	 * @return array
+	 */
+	function returnArrayWithAnonymousClass()
+	{
+	    new class
+		{
+		/**
+		 * @return void
+		 */
+		public function test()
+			{
+		    return;
+		}
+	    };
+
+	    return array();
+	}
 }


### PR DESCRIPTION
- Support both a return type and a description
- Fix false positive when function contains closure or anonymous class
- fixes #228 

Adds tests to cover these changes

Changes adopted from Squiz.Commenting.FunctionComment PHPCS 3.x branch which addressed these issues. 

Note: PEAR.ControlStructures.MultiLineCondition.Alignment is struggling here the same lines gives
- Multi-line IF statement not indented correctly; expected 32 spaces but found 28.
or after fixing
- Multi-line IF statement not indented correctly; expected 28 spaces but found 32.
This is a PHPCS indenting issue.