### PR TITLE
Add codestyle for language files

### DIFF
--- a/manual/basic-guidelines.md
+++ b/manual/basic-guidelines.md
@@ -4,7 +4,8 @@ This chapter outlines the basic guidelines covering files contributed to the Joo
 
 All files contributed to Joomla must be: 
 
-* Stored as ASCII text
+* Stored as ASCII text  
+  Exceptions: languages locales and some test files containing non-ASCII characters  
 * Use UTF-8 character encoding
 * Be Unix formatted following these rules. 
 	1. Lines must end only with a line feed (LF). 

--- a/manual/ini.md
+++ b/manual/ini.md
@@ -1,0 +1,42 @@
+.ini Language Files Format
+
+An .ini file is composed of strings and comments. See [Specification of language files](https://docs.joomla.org/Specification_of_language_files).
+
+### Formatting
+
+#### Comments
+There are 2 types of comments:
+- Comments used as sections, to clarify the use of a group of strings.
+- Comments used to inform translators of some characteristics of the string(s) just below. These should not be preceded by a blank line.
+
+#### Strings
+- The lines commented should start with a semi-colon.
+- The strings should be alphabetically ordered using the "Standard Alphabetical Order" and not the "ASCII order". This mostly means here that the underscore is sorted BEFORE the letters.
+
+Example:  
+```ini
+COM_ABCD_FORMAT_WHATEVER
+```
+comes before
+```ini
+COM_ABCD_FORMATTING_WHATEVER
+```  
+
+Some specific text editors only sort by "ASCII order" and should not be used.
+
+### Plugins
+Some IDEs have specific plugins to sort the lines by "Standard Alphabetical Order".
+
+Examples:
+- PhpStorm [String Manipulation](https://plugins.jetbrains.com/plugin/2162-string-manipulation)
+- Eclipse [Sortit](https://github.com/channingwalton/eclipse-sortit/tree/master/com.teaminabox.eclipse.sortit)
+- Atom [Sort selected elements](https://github.com/BlueSilverCat/sort-selected-elements)
+
+It may be necessary to set the sorting to "Case Insensitive Sort" to obtain the correct results.
+
+### Online tools
+There is also an online tool which lets order this way (among other goodies): https://wordcounter.net/alphabetize
+
+### Notes
+When the file includes commented sections, the strings should be alphabetically ordered in each section.
+Warning: when the comments concern specific strings and sorting has modified the order, the comments should be moved to the right place.

--- a/manual/ini.md
+++ b/manual/ini.md
@@ -28,9 +28,10 @@ Some specific text editors only sort by "ASCII order" and should not be used.
 Some IDEs have specific plugins to sort the lines by "Standard Alphabetical Order".
 
 Examples:
-- PhpStorm [String Manipulation](https://plugins.jetbrains.com/plugin/2162-string-manipulation)
-- Eclipse [Sortit](https://github.com/channingwalton/eclipse-sortit/tree/master/com.teaminabox.eclipse.sortit)
 - Atom [Sort selected elements](https://github.com/BlueSilverCat/sort-selected-elements)
+- Eclipse [Sortit](https://github.com/channingwalton/eclipse-sortit/tree/master/com.teaminabox.eclipse.sortit)
+- NetBeans [Sort line tools](http://plugins.netbeans.org/plugin/45925/sort-line-tools)
+- PhpStorm [String Manipulation](https://plugins.jetbrains.com/plugin/2162-string-manipulation)
 
 It may be necessary to set the sorting to "Case Insensitive Sort" to obtain the correct results.
 

--- a/manual/ini.md
+++ b/manual/ini.md
@@ -10,6 +10,7 @@ There are 2 types of comments:
 - Comments used to inform translators of some characteristics of the string(s) just below. These should not be preceded by a blank line.
 
 #### Strings
+- All language strings are in British English (en-GB). See [Joomla! en-GB User Interface Text Guidelines](https://developer.joomla.org/en-gb-user-interface-text-guidelines/introduction.html)
 - The lines commented should start with a semi-colon.
 - The strings should be alphabetically ordered using the "Standard Alphabetical Order" and not the "ASCII order". This mostly means here that the underscore is sorted BEFORE the letters.
 


### PR DESCRIPTION
As per the discussion in the CMS Maintainers chat, here is a first draft of the codestyle for our language files.

It would be good to have separate section here for INI files but I don't see how I can do that:
![image](https://user-images.githubusercontent.com/359377/46274262-1af7aa80-c559-11e8-9b17-e668b6dcca6b.png)

Pinging @infograf768 as the text is his :)