### PR TITLE
Fix issues with closures. Fixes #230 and #231

### DIFF
--- a/Joomla/Sniffs/ControlStructures/ControlStructuresBracketsSniff.php
+++ b/Joomla/Sniffs/ControlStructures/ControlStructuresBracketsSniff.php
@@ -175,11 +175,15 @@ class Joomla_Sniffs_ControlStructures_ControlStructuresBracketsSniff implements 
 
 			$nested = 0;
 
-			// Anonymous classes and functions set the indent at one plus their own indent level.
-			if (isset($tokens[$stackPtr]['nested_parenthesis']))
+			/**
+			 * Take into account any nested parenthesis that don't contribute to the level (often required for
+			 * closures and anonymous classes
+			 */
+			if (array_key_exists('nested_parenthesis', $tokens[$stackPtr]))
 			{
 				$nested = count($tokens[$stackPtr]['nested_parenthesis']);
 			}
+
 			$expected = ($tokens[$stackPtr]['level'] + $nested) * $this->indent;
 
 			// We need to divide by 4 here since there is a space vs tab intent in the check vs token

--- a/Joomla/Sniffs/ControlStructures/ControlStructuresBracketsSniff.php
+++ b/Joomla/Sniffs/ControlStructures/ControlStructuresBracketsSniff.php
@@ -173,16 +173,14 @@ class Joomla_Sniffs_ControlStructures_ControlStructuresBracketsSniff implements 
 				}
 			}
 
+			$nested = 0;
+
 			// Anonymous classes and functions set the indent at one plus their own indent level.
-			if ($phpcsFile->hasCondition($stackPtr, T_CLOSURE) === true
-				|| $phpcsFile->hasCondition($stackPtr, T_ANON_CLASS) === true)
+			if (isset($tokens[$stackPtr]['nested_parenthesis']))
 			{
-				$expected = ($tokens[$stackPtr]['level'] + 1) * $this->indent;
+				$nested = count($tokens[$stackPtr]['nested_parenthesis']);
 			}
-			else
-			{
-				$expected = $tokens[$stackPtr]['level'] * $this->indent;
-			}
+			$expected = ($tokens[$stackPtr]['level'] + $nested) * $this->indent;
 
 			// We need to divide by 4 here since there is a space vs tab intent in the check vs token
 			$expected /= $this->indent;

--- a/Joomla/Tests/ControlStructures/ControlStructuresBracketsUnitTest.inc
+++ b/Joomla/Tests/ControlStructures/ControlStructuresBracketsUnitTest.inc
@@ -168,3 +168,49 @@ $this->attachRule(
 		}
 	}
 );
+
+// Round 2 Closure indentation tests
+$i = 1;
+$func = function ($match) use ($query, $args, &$i)
+{
+	if (isset($match[6]) && $match[6] === '%')
+	{
+		return '%';
+	}
+	// No argument required, do not increment the argument index.
+	switch ($match[5])
+{
+		case 't':
+			return $query->currentTimestamp();
+			break;
+		case 'z':
+			if (true)
+			{
+				return $query->nullDate(true);
+			}
+			return $query->nullDate(false);
+			break;
+		case 'Z':
+			return $query->nullDate(true);
+			break;
+	}
+};
+
+class Foo
+{
+	public function format($format)
+	{
+		$query = $this;
+		$args  = \array_slice(\func_get_args(), 1);
+		array_unshift($args, null);
+
+		$i    = 1;
+		$func = function ($match) use ($query, $args, &$i) {
+			if (isset($match[6]) && $match[6] === '%')
+			{
+				return '%';
+			}
+
+		};
+	}
+}

--- a/Joomla/Tests/ControlStructures/ControlStructuresBracketsUnitTest.inc
+++ b/Joomla/Tests/ControlStructures/ControlStructuresBracketsUnitTest.inc
@@ -185,7 +185,7 @@ $func = function ($match) use ($query, $args, &$i)
 			break;
 		case 'z':
 			if (true)
-			{
+				{
 				return $query->nullDate(true);
 			}
 			return $query->nullDate(false);
@@ -207,7 +207,7 @@ class Foo
 		$i    = 1;
 		$func = function ($match) use ($query, $args, &$i) {
 			if (isset($match[6]) && $match[6] === '%')
-			{
+		{
 				return '%';
 			}
 

--- a/Joomla/Tests/ControlStructures/ControlStructuresBracketsUnitTest.inc.fixed
+++ b/Joomla/Tests/ControlStructures/ControlStructuresBracketsUnitTest.inc.fixed
@@ -167,3 +167,49 @@ $this->attachRule(
 		}
 	}
 );
+
+// Round 2 Closure indentation tests
+$i = 1;
+$func = function ($match) use ($query, $args, &$i)
+{
+	if (isset($match[6]) && $match[6] === '%')
+	{
+		return '%';
+	}
+	// No argument required, do not increment the argument index.
+	switch ($match[5])
+	{
+		case 't':
+			return $query->currentTimestamp();
+			break;
+		case 'z':
+			if (true)
+			{
+				return $query->nullDate(true);
+			}
+			return $query->nullDate(false);
+			break;
+		case 'Z':
+			return $query->nullDate(true);
+			break;
+	}
+};
+
+class Foo
+{
+	public function format($format)
+	{
+		$query = $this;
+		$args  = \array_slice(\func_get_args(), 1);
+		array_unshift($args, null);
+
+		$i    = 1;
+		$func = function ($match) use ($query, $args, &$i) {
+			if (isset($match[6]) && $match[6] === '%')
+			{
+				return '%';
+			}
+
+		};
+	}
+}

--- a/Joomla/Tests/ControlStructures/ControlStructuresBracketsUnitTest.php
+++ b/Joomla/Tests/ControlStructures/ControlStructuresBracketsUnitTest.php
@@ -42,6 +42,8 @@ class Joomla_Tests_ControlStructures_ControlStructuresBracketsUnitTest extends A
 				126 => 1,
 				135 => 1,
 				182 => 1,
+				188 => 1,
+				210 => 1,
 			   );
 	}
 

--- a/Joomla/Tests/ControlStructures/ControlStructuresBracketsUnitTest.php
+++ b/Joomla/Tests/ControlStructures/ControlStructuresBracketsUnitTest.php
@@ -41,6 +41,7 @@ class Joomla_Tests_ControlStructures_ControlStructuresBracketsUnitTest extends A
 				120 => 1,
 				126 => 1,
 				135 => 1,
+				182 => 1,
 			   );
 	}
 


### PR DESCRIPTION
So basically for example in the conditions https://github.com/joomla/coding-standards/blob/4c1503f1ae304f4a83f012751730b1e03ecfdbc2/Joomla/Tests/ControlStructures/ControlStructuresBracketsUnitTest.inc#L86 here `attachRule` isn't considered a condition and therefore doesn't count towards the number of levels. Instead it's considered a `nested_parenthesis` (whatever that means) and the same for the `usort` function in the other unit test we had. We blindly therefore added one level to the count but instead we should actually check for the `nested_parenthesis` and count how many of them there are