### PR TITLE
Fix Implicit true comparison

### DIFF
--- a/Joomla/Sniffs/ControlStructures/ControlStructuresBracketsSniff.php
+++ b/Joomla/Sniffs/ControlStructures/ControlStructuresBracketsSniff.php
@@ -179,7 +179,7 @@ class Joomla_Sniffs_ControlStructures_ControlStructuresBracketsSniff implements 
 			 * Take into account any nested parenthesis that don't contribute to the level (often required for
 			 * closures and anonymous classes
 			 */
-			if (array_key_exists('nested_parenthesis', $tokens[$stackPtr]))
+			if (array_key_exists('nested_parenthesis', $tokens[$stackPtr]) === true)
 			{
 				$nested = count($tokens[$stackPtr]['nested_parenthesis']);
 			}


### PR DESCRIPTION
Fixes the Implicit true comparison from #242 . As I understand it, best practice is to always avoid Implicit true comparisons (also mandated by PHPCS when contributing to their Repo)