### PR TITLE
Adding testrunners for PHP7.3/.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,11 @@ matrix:
     - php: 7.0
     - php: 7.1
     - php: 7.2
+    - php: 7.3
+    - php: 7.4
     - php: nightly
   allow_failures:
-    - php: 7.2
+    - php: 7.4
     - php: nightly
 
 before_script:


### PR DESCRIPTION
This runs the tests with PHP7.3 and PHP7.4 and changes the allowed failures from 7.2 to 7.4 (and nightly)