### PR TITLE
Don't allow package tags in namespaced files

### DIFF
--- a/Joomla/Sniffs/Commenting/FileCommentSniff.php
+++ b/Joomla/Sniffs/Commenting/FileCommentSniff.php
@@ -266,8 +266,8 @@ class Joomla_Sniffs_Commenting_FileCommentSniff implements PHP_CodeSniffer_Sniff
 			// We don't use package tags in namespaced classes.
 			if ($tag === '@package' || $tag === '@subpackage')
 			{
-				// Check for namespaced classes.
-				$namespaced = $phpcsFile->findNext(array(T_NAMESPACE), 0);
+				//Check for a namespace token, if certain other tokens are found we can move on. This keeps us from searching the whole file.
+				$namespaced = $phpcsFile->findNext(array(T_NAMESPACE, T_CLASS, T_INTERFACE, T_TRAIT), 0);
 				$classes    = array(T_CLASS, T_INTERFACE, T_TRAIT);
 				$class      = $phpcsFile->findNext($classes, 0);
 

--- a/Joomla/Sniffs/Commenting/FileCommentSniff.php
+++ b/Joomla/Sniffs/Commenting/FileCommentSniff.php
@@ -266,7 +266,7 @@ class Joomla_Sniffs_Commenting_FileCommentSniff implements PHP_CodeSniffer_Sniff
 			// We don't use package tags in namespaced classes.
 			if ($tag === '@package' || $tag === '@subpackage')
 			{
-				//Check for a namespace token, if certain other tokens are found we can move on. This keeps us from searching the whole file.
+				// Check for a namespace token, if certain other tokens are found we can move on. This keeps us from searching the whole file.
 				$namespaced = $phpcsFile->findNext(array(T_NAMESPACE, T_CLASS, T_INTERFACE, T_TRAIT), 0);
 				$classes    = array(T_CLASS, T_INTERFACE, T_TRAIT);
 				$class      = $phpcsFile->findNext($classes, 0);

--- a/Joomla/Sniffs/Commenting/FileCommentSniff.php
+++ b/Joomla/Sniffs/Commenting/FileCommentSniff.php
@@ -263,31 +263,31 @@ class Joomla_Sniffs_Commenting_FileCommentSniff implements PHP_CodeSniffer_Sniff
 
 		foreach ($this->tags as $tag => $tagData)
 		{
+			// We don't use package tags in namespaced code
+			if ($tag === '@package' || $tag === '@subpackage')
+			{
+				// Check for a namespace token, if certain other tokens are found we can move on. This keeps us from searching the whole file.
+				$namespaced = $phpcsFile->findNext(array(T_NAMESPACE, T_CLASS, T_INTERFACE, T_TRAIT), 0);
+
+				// If we found a namespace token we skip the error, otherwise we let the error happen
+				if ($tokens[$namespaced]['code'] === T_NAMESPACE)
+				{
+					if (isset($tagTokens[$tag]) === true)
+					{
+						$error = '%s tag found in namespaced %s comment';
+						$data  = array(
+								$tag,
+								$docBlock,
+							);
+						$phpcsFile->addError($error, $commentEnd, ucfirst(substr($tag, 1)) . 'TagInNamespace', $data);
+					}
+
+					continue;
+				}
+			}
+
 			if (isset($tagTokens[$tag]) === false)
 			{
-				// We don't use package tags in namespaced code.
-				if ($tag === '@package' || $tag === '@subpackage')
-				{
-					// Check for a namespace token, if certain other tokens are found we can move on. This keeps us from searching the whole file.
-					$namespaced = $phpcsFile->findNext(array(T_NAMESPACE, T_CLASS, T_INTERFACE, T_TRAIT), 0);
-
-					// If we found the tag and a namespace token trigger the error.
-					if ($tokens[$namespaced]['code'] === T_NAMESPACE)
-					{
-						if (isset($tagTokens[$tag]) === true)
-						{
-							$error = '%s tag found in namespaced %s comment';
-							$data  = array(
-									$tag,
-									$docBlock,
-								);
-							$phpcsFile->addError($error, $commentEnd, ucfirst(substr($tag, 1)) . 'TagInNamespace', $data);
-						}
-
-						continue;
-					}
-				}
-
 				if ($tagData['required'] === true)
 				{
 					$error = 'Missing %s tag in %s comment';

--- a/Joomla/Sniffs/Commenting/FileCommentSniff.php
+++ b/Joomla/Sniffs/Commenting/FileCommentSniff.php
@@ -278,9 +278,9 @@ class Joomla_Sniffs_Commenting_FileCommentSniff implements PHP_CodeSniffer_Sniff
 					{
 						$error = '%s tag found in namespaced %s comment';
 						$data  = array(
-								$tag,
-								$docBlock,
-							);
+							$tag,
+							$docBlock,
+						);
 						$phpcsFile->addError($error, $commentEnd, ucfirst(substr($tag, 1)) . 'TagInNamespace', $data);
 					}
 

--- a/Joomla/Sniffs/Commenting/FileCommentSniff.php
+++ b/Joomla/Sniffs/Commenting/FileCommentSniff.php
@@ -263,14 +263,16 @@ class Joomla_Sniffs_Commenting_FileCommentSniff implements PHP_CodeSniffer_Sniff
 
 		foreach ($this->tags as $tag => $tagData)
 		{
-			// We don't use package tags in namespaced code
+			// We don't use package tags in namespaced classes.
 			if ($tag === '@package' || $tag === '@subpackage')
 			{
-				// Check for a namespace token, if certain other tokens are found we can move on. This keeps us from searching the whole file.
-				$namespaced = $phpcsFile->findNext(array(T_NAMESPACE, T_CLASS, T_INTERFACE, T_TRAIT), 0);
+				// Check for namespaced classes.
+				$namespaced = $phpcsFile->findNext(array(T_NAMESPACE), 0);
+				$classes    = array(T_CLASS, T_INTERFACE, T_TRAIT);
+				$class      = $phpcsFile->findNext($classes, 0);
 
-				// If we found a namespace token we skip the error, otherwise we let the error happen
-				if ($tokens[$namespaced]['code'] === T_NAMESPACE)
+				// If we found a namespaced class trigger the error.
+				if ($tokens[$namespaced]['code'] === T_NAMESPACE && in_array($tokens[$class]['code'], $classes, true))
 				{
 					if (isset($tagTokens[$tag]) === true)
 					{

--- a/Joomla/Sniffs/Commenting/FileCommentSniff.php
+++ b/Joomla/Sniffs/Commenting/FileCommentSniff.php
@@ -265,7 +265,7 @@ class Joomla_Sniffs_Commenting_FileCommentSniff implements PHP_CodeSniffer_Sniff
 		{
 			if (isset($tagTokens[$tag]) === false)
 			{
-				// We don't use package tags in namespaced code
+				// We don't use package tags in namespaced code.
 				if ($tag === '@package' || $tag === '@subpackage')
 				{
 					// Check for a namespace token, if certain other tokens are found we can move on. This keeps us from searching the whole file.

--- a/Joomla/Sniffs/Commenting/FileCommentSniff.php
+++ b/Joomla/Sniffs/Commenting/FileCommentSniff.php
@@ -265,21 +265,31 @@ class Joomla_Sniffs_Commenting_FileCommentSniff implements PHP_CodeSniffer_Sniff
 		{
 			if (isset($tagTokens[$tag]) === false)
 			{
+				// We don't use package tags in namespaced code
+				if ($tag === '@package' || $tag === '@subpackage')
+				{
+					// Check for a namespace token, if certain other tokens are found we can move on. This keeps us from searching the whole file.
+					$namespaced = $phpcsFile->findNext(array(T_NAMESPACE, T_CLASS, T_INTERFACE, T_TRAIT), 0);
+
+					// If we found the tag and a namespace token trigger the error.
+					if ($tokens[$namespaced]['code'] === T_NAMESPACE)
+					{
+						if (isset($tagTokens[$tag]) === true)
+						{
+							$error = '%s tag found in namespaced %s comment';
+							$data  = array(
+									$tag,
+									$docBlock,
+								);
+							$phpcsFile->addError($error, $commentEnd, ucfirst(substr($tag, 1)) . 'TagInNamespace', $data);
+						}
+
+						continue;
+					}
+				}
+
 				if ($tagData['required'] === true)
 				{
-					// We don't use package tags in namespaced code
-					if ($tag == '@package')
-					{
-						// Check for a namespace token, if certain other tokens are found we can move on. This keeps us from searching the whole file.
-						$namespaced = $phpcsFile->findNext(array(T_NAMESPACE, T_CLASS, T_INTERFACE, T_TRAIT), 0);
-
-						// If we found a namespace token we skip the error, otherwise we let the error happen
-						if ($tokens[$namespaced]['code'] === T_NAMESPACE)
-						{
-							continue;
-						}
-					}
-
 					$error = 'Missing %s tag in %s comment';
 					$data  = array(
 							  $tag,


### PR DESCRIPTION
Pull request for https://github.com/joomla/joomla-cms/issues/26395.

@mbabker please review. Should this be applied to all namespaced files or only to namespaced classes? We don't have the former in the CMS so not sure how to handle those.