### PR TITLE
Fix compatibility with PHP 7.4 (3.x)

### DIFF
--- a/Joomla/Sniffs/Commenting/FileCommentSniff.php
+++ b/Joomla/Sniffs/Commenting/FileCommentSniff.php
@@ -419,13 +419,13 @@ class FileCommentSniff implements Sniff
 			{
 				$nameBits = explode('_', $newContent);
 				$firstBit = array_shift($nameBits);
-				$newName  = strtoupper($firstBit{0}) . substr($firstBit, 1) . '_';
+				$newName  = strtoupper($firstBit[0]) . substr($firstBit, 1) . '_';
 
 				foreach ($nameBits as $bit)
 				{
 					if ($bit !== '')
 					{
-						$newName .= strtoupper($bit{0}) . substr($bit, 1) . '_';
+						$newName .= strtoupper($bit[0]) . substr($bit, 1) . '_';
 					}
 				}
 

--- a/Joomla/Sniffs/Commenting/SingleCommentSniff.php
+++ b/Joomla/Sniffs/Commenting/SingleCommentSniff.php
@@ -42,7 +42,7 @@ class SingleCommentSniff implements Sniff
 		$comment    = trim($tokens[$stackPtr]['content']);
 
 		// Hash comments are not allowed.
-		if ($tokens[$stackPtr]['content']{0} === '#')
+		if ($tokens[$stackPtr]['content'][0] === '#')
 		{
 			$phpcsFile->recordMetric($stackPtr, 'Inline comment style', '# ...');
 
@@ -57,21 +57,21 @@ class SingleCommentSniff implements Sniff
 				$phpcsFile->fixer->replaceToken($stackPtr, $newComment);
 			}
 		}
-		elseif ($tokens[$stackPtr]['content']{0} === '/' && $tokens[$stackPtr]['content']{1} === '/')
+		elseif ($tokens[$stackPtr]['content'][0] === '/' && $tokens[$stackPtr]['content'][1] === '/')
 		{
 			$phpcsFile->recordMetric($stackPtr, 'Inline comment style', '// ...');
 			$singleLine = true;
 		}
-		elseif ($tokens[$stackPtr]['content']{0} === '/' && $tokens[$stackPtr]['content']{1} === '*')
+		elseif ($tokens[$stackPtr]['content'][0] === '/' && $tokens[$stackPtr]['content'][1] === '*')
 		{
 			$phpcsFile->recordMetric($stackPtr, 'Inline comment style', '/* ... */');
 		}
 
 		// Always have a space between // and the start of the comment text.
 		// The exception to this is if the preceding line consists of a single open bracket.
-		if ($tokens[$stackPtr]['content']{0} === '/' && $tokens[$stackPtr]['content']{1} === '/' && isset($tokens[$stackPtr]['content']{2})
-			&& $tokens[$stackPtr]['content']{2} !== ' ' && isset($tokens[($stackPtr - 1)]['content']{0})
-			&& $tokens[($stackPtr - 1)]['content']{0} !== '}'
+		if ($tokens[$stackPtr]['content'][0] === '/' && $tokens[$stackPtr]['content'][1] === '/' && isset($tokens[$stackPtr]['content'][2])
+			&& $tokens[$stackPtr]['content'][2] !== ' ' && isset($tokens[($stackPtr - 1)]['content'][0])
+			&& $tokens[($stackPtr - 1)]['content'][0] !== '}'
 		)
 		{
 			$error = 'Missing space between the // and the start of the comment text.';
@@ -91,9 +91,9 @@ class SingleCommentSniff implements Sniff
 		 * the line is a continuation of a complete sentence,
 		 * the term is code and is case sensitive.(@todo)
 		 */
-		if (($singleLine === true && isset($tokens[$stackPtr]['content']{3}) && $tokens[$stackPtr]['content']{2} === ' '
-			&& $tokens[$stackPtr]['content']{3} !== strtoupper($tokens[$stackPtr]['content']{3})) || (isset($comment{2}) && $comment{0} === '*'
-			&& $comment{1} === ' ' && $comment{2} !== strtoupper($comment{2}))
+		if (($singleLine === true && isset($tokens[$stackPtr]['content'][3]) && $tokens[$stackPtr]['content'][2] === ' '
+			&& $tokens[$stackPtr]['content'][3] !== strtoupper($tokens[$stackPtr]['content'][3])) || (isset($comment[2]) && $comment[0] === '*'
+			&& $comment[1] === ' ' && $comment[2] !== strtoupper($comment[2]))
 		)
 		{
 			$error = 'Comment must start with a capital letter; found "%s"';
@@ -101,13 +101,13 @@ class SingleCommentSniff implements Sniff
 
 			if ($singleLine === true)
 			{
-				$data       = array($comment{3});
+				$data       = array($comment[3]);
 				$newComment = ltrim($tokens[$stackPtr]['content'], '\// ');
 				$newComment = '// ' . ucfirst($newComment);
 			}
 			else
 			{
-				$data       = array($comment{2});
+				$data       = array($comment[2]);
 				$padding    = (strlen($tokens[$stackPtr]['content']) - strlen($comment));
 				$padding    = str_repeat("\t", $padding - 2);
 				$newComment = ltrim($comment, '* ');
@@ -119,7 +119,7 @@ class SingleCommentSniff implements Sniff
 			{
 				$test = trim($tokens[$previous]['content']);
 
-				if ('.' === $test{(strlen($test) - 1)})
+				if ('.' === $test[(strlen($test) - 1)])
 				{
 					$fix = $phpcsFile->addFixableError($error, $stackPtr, 'LowerCaseAfterSentenceEnd', $data);
 

--- a/Joomla/Sniffs/NamingConventions/ValidFunctionNameSniff.php
+++ b/Joomla/Sniffs/NamingConventions/ValidFunctionNameSniff.php
@@ -84,7 +84,7 @@ class ValidFunctionNameSniff extends PEARValidFunctionNameSniff
 		}
 
 		// Joomla change: Methods must not have an underscore on the front.
-		if ($scopeSpecified === true && $methodName{0} === '_')
+		if ($scopeSpecified === true && $methodName[0] === '_')
 		{
 			$error = '%s method name "%s" must not be prefixed with an underscore';
 			$data  = array(
@@ -105,7 +105,7 @@ class ValidFunctionNameSniff extends PEARValidFunctionNameSniff
 		 */
 		$testMethodName = $methodName;
 
-		if ($scopeSpecified === false && $methodName{0} === '_')
+		if ($scopeSpecified === false && $methodName[0] === '_')
 		{
 			$testMethodName = substr($methodName, 1);
 		}


### PR DESCRIPTION
Array and string offset acces using curly braces is deprecated since PHP 7.4.

Ref: https://www.php.net/manual/en/migration74.deprecated.php#migration74.deprecated.core.array-string-access-curly-brace