### PR TITLE
Fixing list of magic methods for naming convention

### DIFF
--- a/Joomla/Sniffs/NamingConventions/ValidFunctionNameSniff.php
+++ b/Joomla/Sniffs/NamingConventions/ValidFunctionNameSniff.php
@@ -24,7 +24,7 @@ class Joomla_Sniffs_NamingConventions_ValidFunctionNameSniff extends PEAR_Sniffs
 	 *
 	 * @var array
 	 */
-	protected $magicMethods = [
+	protected $magicMethods = array(
 		'construct'   => true,
 		'destruct'    => true,
 		'call'        => true,
@@ -42,7 +42,7 @@ class Joomla_Sniffs_NamingConventions_ValidFunctionNameSniff extends PEAR_Sniffs
 		'set_state'   => true,
 		'clone'       => true,
 		'debuginfo'   => true,
-	];
+	);
 
 	/**
 	 * Processes the tokens within the scope.

--- a/Joomla/Sniffs/NamingConventions/ValidFunctionNameSniff.php
+++ b/Joomla/Sniffs/NamingConventions/ValidFunctionNameSniff.php
@@ -20,6 +20,31 @@ if (class_exists('PEAR_Sniffs_NamingConventions_ValidFunctionNameSniff', true) =
 class Joomla_Sniffs_NamingConventions_ValidFunctionNameSniff extends PEAR_Sniffs_NamingConventions_ValidFunctionNameSniff
 {
 	/**
+	 * A list of all PHP magic methods.
+	 *
+	 * @var array
+	 */
+	protected $magicMethods = [
+		'construct'   => true,
+		'destruct'    => true,
+		'call'        => true,
+		'callstatic'  => true,
+		'get'         => true,
+		'set'         => true,
+		'isset'       => true,
+		'unset'       => true,
+		'sleep'       => true,
+		'wakeup'      => true,
+		'serialize'   => true,
+		'unserialize' => true,
+		'tostring'    => true,
+		'invoke'      => true,
+		'set_state'   => true,
+		'clone'       => true,
+		'debuginfo'   => true,
+	];
+
+	/**
 	 * Processes the tokens within the scope.
 	 *
 	 * Extends PEAR.NamingConventions.ValidFunctionName.processTokenWithinScope to remove the requirement for leading underscores on


### PR DESCRIPTION
What the title says. The old PEAR sniff is missing methods like serialize and unserialize.