### PR TITLE
Add "static analysis" Composer keyword

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "joomla/coding-standards",
     "type": "phpcodesniffer-standard",
     "description": "Joomla Coding Standards",
-    "keywords": ["joomla", "coding standards", "phpcs", "php codesniffer"],
+    "keywords": ["joomla", "coding standards", "phpcs", "php codesniffer", "static analysis"],
     "homepage": "https://github.com/joomla/coding-standards",
     "license": "GPL-2.0-or-later",
     "authors": [


### PR DESCRIPTION
As per https://getcomposer.org/doc/04-schema.md#keywords by including "static analysis" as a keyword in the `composer.json` file, Composer 2.4.0-RC1 and later will prompt users if the package is installed with `composer require` instead of `composer require --dev`. See https://github.com/composer/composer/pull/10960 for more info.