### PR TITLE
Update PHP_CodeSniffer repository link

### DIFF
--- a/Joomla/ExampleRulesets/README.md
+++ b/Joomla/ExampleRulesets/README.md
@@ -4,7 +4,7 @@
 
 For consuming packages there are some items that will typically result in creating their own project ruleset.xml, rather than just directly using the Joomla ruleset.xml. A project ruleset.xml allows the coding standard to be selectivly applied for excluding 3rd party libraries, for consideration of backwards compatability in existing projects, or for adjustments necessary for projects that do not need php 5.3 compatability (which will be removed in a future version of the Joomla Coding Standard in connection of the end of php 5.3 support in all active Joomla Projects). 
 
-For information on [selectivly applying rules read details in the PHP CodeSniffer wiki](https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml#selectively-applying-rules)
+For information on [selectivly applying rules read details in the PHP CodeSniffer wiki](https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Annotated-ruleset.xml#selectively-applying-rules)
 
 #### Common Rule Set Adjustments
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Joomla Coding Standards [![Build Status](https://travis-ci.org/joomla/coding-sta
 
 [![Latest Stable Version](https://poser.pugx.org/joomla/coding-standards/v/stable.svg)](https://packagist.org/packages/joomla/coding-standards) [![Latest Unstable Version](https://poser.pugx.org/joomla/coding-standards/v/unstable.svg)](https://packagist.org/packages/joomla/coding-standards) [![License](https://poser.pugx.org/joomla/coding-standards/license.svg)](https://packagist.org/packages/joomla/coding-standards)
 
-This repository includes the [Joomla](https://developer.joomla.org) coding standard definition for [PHP Codesniffer](https://github.com/squizlabs/PHP_CodeSniffer) along with a few other helpful resources.  The PHP_CodeSniffer standard will never be 100% accurate, but should be viewed as a strong set of guidelines while writing software for Joomla.
+This repository includes the [Joomla](https://developer.joomla.org) coding standard definition for [PHP Codesniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer) along with a few other helpful resources.  The PHP_CodeSniffer standard will never be 100% accurate, but should be viewed as a strong set of guidelines while writing software for Joomla.
 
 See Joomla coding standards documentation at [https://developer.joomla.org/coding-standards.html](https://developer.joomla.org/coding-standards.html)
 
@@ -20,7 +20,7 @@ If you want to contribute and improve this documentation, you can find the sourc
 ## Requirements
 
 * PHP 5.3+
-* [PHP Codesniffer](https://github.com/squizlabs/PHP_CodeSniffer) 2.8+
+* [PHP Codesniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer) 2.8+
 
 **Important note**: currently the latest PHPCS is the 3.x series. There is [a development branch](https://github.com/joomla/coding-standards/tree/3.x-dev) for the Joomla custom sniffs Which is compatible with the PHPCS 3.x series. Although PEAR and composer give you the option to install PHPCS 3.x by default the Joomla custom sniffs releases are currently only compatible with PHPCS 2.x and will not work, so we remind you to always install the PHPCS 2.x series if you are using the Joomla custom sniffs. 
 If you want to test the [Joomla Code Standard development branch for PHPCS 3.x](https://github.com/joomla/coding-standards/tree/3.x-dev), please manually install the 3.x branch.
@@ -88,7 +88,7 @@ Alternatively if it isn't installed you can still reference it by path like:
 
 For consuming packages there are some items that will typically result in creating their own project ruleset.xml, rather than just directly using the Joomla ruleset.xml. A project ruleset.xml allows the coding standard to be selectively applied for excluding 3rd party libraries, for consideration of backwards compatibility in existing projects, or for adjustments necessary for projects that do not need PHP 5.3 compatibility (which will be removed in a future version of the Joomla Coding Standard in connection of the end of PHP 5.3 support in all active Joomla Projects).
 
-For information on [selectively applying rules read details in the PHP CodeSniffer wiki](https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml#selectively-applying-rules)
+For information on [selectively applying rules read details in the PHP CodeSniffer wiki](https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Annotated-ruleset.xml#selectively-applying-rules)
 
 #### Common Rule Set Adjustments
 


### PR DESCRIPTION
PHP_CodeSniffer has moved to a new GitHub organization. The `squizlabs/PHP_CodeSniffer` repository is now archived and the project is actively maintained at https://github.com/PHPCSStandards/PHP_CodeSniffer.

See: https://github.com/squizlabs/PHP_CodeSniffer/issues/3932