### PR TITLE
Fix PHP_CodeSniffer wiki link

### DIFF
--- a/Joomla/ExampleRulesets/README.md
+++ b/Joomla/ExampleRulesets/README.md
@@ -4,7 +4,7 @@
 
 For consuming packages there are some items that will typically result in creating their own project ruleset.xml, rather than just directly using the Joomla ruleset.xml. A project ruleset.xml allows the coding standard to be selectivly applied for excluding 3rd party libraries, for consideration of backwards compatability in existing projects, or for adjustments necessary for projects that do not need php 5.3 compatability (which will be removed in a future version of the Joomla Coding Standard in connection of the end of php 5.3 support in all active Joomla Projects). 
 
-For information on [selectivly applying rules read details in the PHP CodeSniffer wiki](https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Annotated-ruleset.xml#selectively-applying-rules)
+For information on [selectivly applying rules read details in the PHP CodeSniffer wiki](https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Annotated-Ruleset#selectively-applying-rules)
 
 #### Common Rule Set Adjustments
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Alternatively if it isn't installed you can still reference it by path like:
 
 For consuming packages there are some items that will typically result in creating their own project ruleset.xml, rather than just directly using the Joomla ruleset.xml. A project ruleset.xml allows the coding standard to be selectively applied for excluding 3rd party libraries, for consideration of backwards compatibility in existing projects, or for adjustments necessary for projects that do not need PHP 5.3 compatibility (which will be removed in a future version of the Joomla Coding Standard in connection of the end of PHP 5.3 support in all active Joomla Projects).
 
-For information on [selectively applying rules read details in the PHP CodeSniffer wiki](https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Annotated-ruleset.xml#selectively-applying-rules)
+For information on [selectively applying rules read details in the PHP CodeSniffer wiki](https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Annotated-Ruleset#selectively-applying-rules)
 
 #### Common Rule Set Adjustments
 


### PR DESCRIPTION
Only after PR #288 was merged, I noticed that one of the original links was incorrect. The wiki page name has changed in the new repository: `Annotated-ruleset.xml` is now `Annotated-Ruleset`.

This fixes the link so they point to the correct page (and valid anchor) in the PHPCSStandards wiki.